### PR TITLE
Paulchen/eng 2612 denso c driver closed loop servoj

### DIFF
--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -151,6 +151,7 @@ private:
 
 ////////////////////////////// Utilities //////////////////////////////
 std::vector<double> VRad2Deg(std::vector<double> vect0);
+std::vector<double> VDeg2Rad(std::vector<double> vect0);
 
 double Rad2Deg(double x);
 double Deg2Rad(double x);

--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -116,6 +116,7 @@ public:
     void bCapEnterProcess();
     void bCapExitProcess();
     void CommandServoJoint(const std::vector<double> joint_position);
+    void ClosedLoopCommandServoJoint(std::vector<double> last_waypoint);
     void ExecuteServoTrajectory(RobotTrajectory& traj);
 
     // utilities

--- a/medra_pybind/pyproject.toml
+++ b/medra_pybind/pyproject.toml
@@ -10,4 +10,4 @@ build-dir = "build"
 
 [project]
 name = "medra_bcap"
-version = "0.1.2"
+version = "0.1.3"

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -79,7 +79,10 @@ void DensoController::bCapServiceStop() {
 
 void DensoController::bCapControllerConnect() {
     SPDLOG_INFO("Getting controller handle. Server ip address: " + std::string(server_ip_address));
-    BCAP_HRESULT hr = bCap_ControllerConnect(iSockFD, "b-CAP", "caoProv.DENSO.VRC9", server_ip_address, "", &lhController);
+    int r = rand();
+    std::string sessionName = std::to_string(r);
+
+    BCAP_HRESULT hr = bCap_ControllerConnect(iSockFD, "b-CAP", "caoProv.DENSO.VRC9", server_ip_address, sessionName.c_str(), &lhController);
     if FAILED(hr) {
         throw bCapException("\033[1;31mbCap_ControllerConnect failed.\033[0m");
     }

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -372,13 +372,13 @@ void DensoController::bCapExitProcess() {
  * Command Servo Joints
  * Send a SlaveMode move to joint position command to the robot.
  *
- * @param joint_position Vector of 8 DOF joint positions in Radians.
+ * @param joint_position_rad Vector of 8 DOF joint positions in Radians.
  * @return 0 if successful, 1 otherwise.
  */
-void DensoController::CommandServoJoint(const std::vector<double> joint_position) {
+void DensoController::CommandServoJoint(const std::vector<double> joint_position_rad) {
     BCAP_HRESULT hr = BCAP_S_OK;
     BCAP_VARIANT vntPose, vntReturn;
-    vntPose = VNTFromRadVector(joint_position);
+    vntPose = VNTFromRadVector(joint_position_rad);
     hr = bCapSlvMove(&vntPose, &vntReturn);
     if (FAILED(hr)) {
         std::string err_description = GetErrorDescription(hr);
@@ -387,8 +387,8 @@ void DensoController::CommandServoJoint(const std::vector<double> joint_position
 
     // Print the joint positions
     // std::string msg = "slvmove (";
-    // for (int i=0; i<joint_position.size(); ++i)
-    //     msg += std::to_string(joint_position[i]) + ' ';
+    // for (int i=0; i<joint_position_rad.size(); ++i)
+    //     msg += std::to_string(joint_position_rad[i]) + ' ';
     // msg += ")";
     // SPDLOG_INFO(msg);
 }
@@ -453,45 +453,45 @@ void DensoController::ClosedLoopCommandServoJoint(std::vector<double> last_waypo
     /* Repeat the last servo j command until the robot reaches tolerance or timeout */
     double CLOSE_LOOP_JOINT_ANGLE_TOLERANCE = 0.0001;  // rad
     double CLOSE_LOOP_TIMEOUT = 0.1;  // 100ms
+    int CLOSE_LOOP_MAX_ITERATION = 10;
 
     BCAP_HRESULT hr;
-    std::vector<double> current_jnt;
-    std::tie(hr, current_jnt) = GetCurJnt();
+    std::vector<double> current_jnt_deg;
+    std::tie(hr, current_jnt_deg) = GetCurJnt();
+    std::vector<double> current_jnt_rad = VDeg2Rad(current_jnt_deg);
     if (FAILED(hr)) {
         SPDLOG_ERROR("Closed loop servo j commands failed to get initial joint position");
     }
     
     // Print the initial joint error
     std::vector<double> joint_error;
-    for (int i = 0; i < current_jnt.size(); ++i) {
-        joint_error.push_back(current_jnt[i] - last_waypoint[i]);
+    for (int i = 0; i < current_jnt_rad.size(); ++i) {
+        joint_error.push_back(current_jnt_rad[i] - last_waypoint[i]);
     }
     char buffer[256] = {0};
     std::sprintf(buffer, "Before closed-loop servo commands, joint error: [%.4f, %.4f, %.4f, %.4f, %.4f, %.4f]",
                 joint_error[0], joint_error[1], joint_error[2], joint_error[3], joint_error[4], joint_error[5]);
     SPDLOG_INFO(std::string(buffer));
-    std::cout << std::string(buffer) << std::endl;
 
-    auto initial_time = std::chrono::steady_clock::now();
     int count = 0;
     while (true) {
-        // Check Timeout
-        auto current_time = std::chrono::steady_clock::now();
-        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(current_time - initial_time).count();
-        if (duration > CLOSE_LOOP_TIMEOUT) {
-            SPDLOG_DEBUG("Closed loop servo j commands TIMEOUT");
+        // Check iteration count
+        if (count >= CLOSE_LOOP_MAX_ITERATION)
+        {
             break;
         }
 
         // Check Joint Tolerance
-        std::tie(hr, current_jnt) = GetCurJnt();
+        std::tie(hr, current_jnt_deg) = GetCurJnt();
         if (FAILED(hr)) {
             SPDLOG_ERROR("Closed loop servo j commands failed to get current joint position");
             break;
         }
+        current_jnt_rad = VDeg2Rad(current_jnt_deg);
+
         bool all_within_tolerance = true;
-        for (int i = 0; i < current_jnt.size(); ++i) {
-            if (std::abs(current_jnt[i] - last_waypoint[i]) > CLOSE_LOOP_JOINT_ANGLE_TOLERANCE) {
+        for (int i = 0; i < current_jnt_rad.size(); ++i) {
+            if (std::abs(current_jnt_rad[i] - last_waypoint[i]) > CLOSE_LOOP_JOINT_ANGLE_TOLERANCE) {
                 all_within_tolerance = false;
                 break;
             }
@@ -507,15 +507,13 @@ void DensoController::ClosedLoopCommandServoJoint(std::vector<double> last_waypo
 
     // Print the joint remaining joint error
     joint_error.clear();
-    for (int i = 0; i < current_jnt.size(); ++i) {
-        joint_error.push_back(current_jnt[i] - last_waypoint[i]);
+    for (int i = 0; i < current_jnt_rad.size(); ++i) {
+        joint_error.push_back(current_jnt_rad[i] - last_waypoint[i]);
     }
     std::memset(buffer, 0, sizeof(buffer));
     std::sprintf(buffer, "After %d closed-loop servo commands, joint error: [%.4f, %.4f, %.4f, %.4f, %.4f, %.4f]",
                 count, joint_error[0], joint_error[1], joint_error[2], joint_error[3], joint_error[4], joint_error[5]);
     SPDLOG_INFO(std::string(buffer));
-    std::cout << std::string(buffer) << std::endl;
-
 }
 
 ////////////////////////////// Utilities //////////////////////////////
@@ -595,6 +593,15 @@ std::vector<double> VRad2Deg(std::vector<double> vect0) {
     resvect.resize(0);
     for (int i = 0; i < int(vect0.size()); i++) {
         resvect.push_back(Rad2Deg(vect0[i]));
+    }
+    return resvect;
+}
+
+std::vector<double> VDeg2Rad(std::vector<double> vect0) {
+    std::vector<double> resvect;
+    resvect.resize(0);
+    for (int i = 0; i < int(vect0.size()); i++) {
+        resvect.push_back(Deg2Rad(vect0[i]));
     }
     return resvect;
 }

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
+#include <cstdio>
 
 
 namespace denso_controller {
@@ -462,9 +463,11 @@ void DensoController::ClosedLoopCommandServoJoint(std::vector<double> last_waypo
     for (int i = 0; i < current_jnt.size(); ++i) {
         joint_error.push_back(current_jnt[i] - last_waypoint[i]);
     }
-    SPDLOG_DEBUG("Before closed-loop servo commands, joint error: [" 
-        + joint_error[0] + ", " + joint_error[1] + ", " + joint_error[2] + ", " 
-        + joint_error[3] + ", " + joint_error[4] + ", " + joint_error[5] + "]");
+    char buffer[256] = {0};
+    std::sprintf(buffer, "Before closed-loop servo commands, joint error: [%.4f, %.4f, %.4f, %.4f, %.4f, %.4f]",
+                joint_error[0], joint_error[1], joint_error[2], joint_error[3], joint_error[4], joint_error[5]);
+    SPDLOG_INFO(std::string(buffer));
+    std::cout << std::string(buffer) << std::endl;
 
     auto initial_time = std::chrono::steady_clock::now();
     int count = 0;
@@ -504,9 +507,12 @@ void DensoController::ClosedLoopCommandServoJoint(std::vector<double> last_waypo
     for (int i = 0; i < current_jnt.size(); ++i) {
         joint_error.push_back(current_jnt[i] - last_waypoint[i]);
     }
-    SPDLOG_DEBUG("After " + count + " closed-loop servo commands, joint error: [" 
-        + joint_error[0] + ", " + joint_error[1] + ", " + joint_error[2] + ", " 
-        + joint_error[3] + ", " + joint_error[4] + ", " + joint_error[5] + "]");
+    std::memset(buffer, 0, sizeof(buffer));
+    std::sprintf(buffer, "After %d closed-loop servo commands, joint error: [%.4f, %.4f, %.4f, %.4f, %.4f, %.4f]",
+                count, joint_error[0], joint_error[1], joint_error[2], joint_error[3], joint_error[4], joint_error[5]);
+    SPDLOG_INFO(std::string(buffer));
+    std::cout << std::string(buffer) << std::endl;
+
 }
 
 ////////////////////////////// Utilities //////////////////////////////

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -471,7 +471,7 @@ void DensoController::ClosedLoopCommandServoJoint(std::vector<double> last_waypo
     char buffer[256] = {0};
     std::sprintf(buffer, "Before closed-loop servo commands, joint error: [%.4f, %.4f, %.4f, %.4f, %.4f, %.4f]",
                 joint_error[0], joint_error[1], joint_error[2], joint_error[3], joint_error[4], joint_error[5]);
-    SPDLOG_INFO(std::string(buffer));
+    SPDLOG_DEBUG(std::string(buffer));
 
     int count = 0;
     while (true) {
@@ -513,7 +513,7 @@ void DensoController::ClosedLoopCommandServoJoint(std::vector<double> last_waypo
     std::memset(buffer, 0, sizeof(buffer));
     std::sprintf(buffer, "After %d closed-loop servo commands, joint error: [%.4f, %.4f, %.4f, %.4f, %.4f, %.4f]",
                 count, joint_error[0], joint_error[1], joint_error[2], joint_error[3], joint_error[4], joint_error[5]);
-    SPDLOG_INFO(std::string(buffer));
+    SPDLOG_DEBUG(std::string(buffer));
 }
 
 ////////////////////////////// Utilities //////////////////////////////


### PR DESCRIPTION
Changes:
- Add use random digits for session name 
- Add close loop servo commands on last waypoint.

Tested on robot
Example:
```
DensoController.cpp:474 | Before closed-loop servo commands, joint error: [0.0000, -0.0001, -0.0012, 0.0001, 0.0014, 0.0000]
DensoController.cpp:523 | After 9 closed-loop servo commands, joint error: [-0.0000, -0.0000, -0.0000, 0.0001, 0.0001, 0.0001]
```