### PR TITLE
feat: Add force sensing to ExecuteServoTrajectory()

### DIFF
--- a/medra_pybind/CMakeLists.txt
+++ b/medra_pybind/CMakeLists.txt
@@ -12,9 +12,10 @@ set(MODULE_NAME medra_bcap)
 set(SOURCES 
     src/bindings.cpp
     src/b-Cap.c
+    src/filter.cpp
     src/DensoController.cpp
     tests/test_execute_servo_trajectory.cpp
-    )
+)
 
 # Cmake version policy
 cmake_policy(SET CMP0057 NEW)
@@ -51,7 +52,13 @@ find_package(pybind11 CONFIG REQUIRED)
 pybind11_add_module(_${MODULE_NAME} ${SOURCES})
 target_link_libraries(_${MODULE_NAME} PRIVATE spdlog::spdlog)
 
-add_executable(test_execute_servo_trajectory tests/test_execute_servo_trajectory.cpp src/DensoController.cpp src/b-Cap.c)
+add_executable(
+  test_execute_servo_trajectory 
+  tests/test_execute_servo_trajectory.cpp 
+  src/filter.cpp
+  src/DensoController.cpp 
+  src/b-Cap.c
+)
 target_link_libraries(test_execute_servo_trajectory PRIVATE spdlog::spdlog)
 
 add_custom_target(generate_stub ALL

--- a/medra_pybind/CMakeLists.txt
+++ b/medra_pybind/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.22.1)
 project(medra_bcap)
 
+set(CMAKE_CXX_STANDARD 20)
+
 message ("CMake Compiler: " ${CMAKE_CXX_COMPILER})
 message ("CMake Compiler ID: " ${CMAKE_CXX_COMPILER_ID})
 message ("CMake Compiler version: " ${CMAKE_CXX_COMPILER_VERSION})
@@ -16,7 +18,6 @@ set(SOURCES
 
 # Cmake version policy
 cmake_policy(SET CMP0057 NEW)
-set (CMAKE_CXX_STANDARD 11)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Include dir

--- a/medra_pybind/CMakeLists.txt
+++ b/medra_pybind/CMakeLists.txt
@@ -9,7 +9,7 @@ message ("CMake Compiler version: " ${CMAKE_CXX_COMPILER_VERSION})
 
 # Set the names and sources of the module
 set(MODULE_NAME medra_bcap)
-set(SOURCES 
+set(PYBIND11_SOURCES 
     src/bindings.cpp
     src/b-Cap.c
     src/filter.cpp
@@ -49,7 +49,7 @@ set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 
 # Add the pybind module
-pybind11_add_module(_${MODULE_NAME} ${SOURCES})
+pybind11_add_module(_${MODULE_NAME} ${PYBIND11_SOURCES})
 target_link_libraries(_${MODULE_NAME} PRIVATE spdlog::spdlog)
 
 add_executable(

--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -14,6 +14,7 @@
 #include <vector>
 #include <tuple>
 #include <atomic>
+#include <optional>
 
 #define DEFAULT_SERVER_IP_ADDRESS    "192.168.0.1"
 #define DEFAULT_SERVER_PORT_NUM      5007
@@ -175,7 +176,12 @@ public:
     // Returns a tuple containing the error code and the joint positions in radians.
     std::tuple<BCAP_HRESULT, std::vector<double>> GetJointPositions();
     // Executes a trajectory of joint angles in radians.
-    bool ExecuteServoTrajectory(RobotTrajectory& traj);
+    bool ExecuteServoTrajectory(
+        RobotTrajectory& traj,
+        std::optional<double> total_force_limit = std::nullopt,
+        std::optional<double> total_torque_limit = std::nullopt,
+        std::optional<std::vector<double>> per_axis_force_torque_limits = std::nullopt
+    );
     BCAP_HRESULT SetTcpLoad(const int32_t tool_value);
     std::tuple<BCAP_HRESULT, std::vector<double>> GetMountingCalib(const char* work_coordinate);
 
@@ -199,9 +205,9 @@ private:
     // This function runs while force_limit_exceeded is false.
     // If the force limit is exceeded, force_limit_exceeded is set to true.
     void RunForceSensingLoop(
-        double total_force_limit,
-        double total_torque_limit,
-        std::vector<double> per_axis_force_torque_limits
+        std::optional<double> total_force_limit,
+        std::optional<double> total_torque_limit,
+        std::optional<std::vector<double>> per_axis_force_torque_limits
     );
 
     // Repeatedly commands a joint position in slave mode until the robot's

--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -235,6 +235,9 @@ private:
     // current joint position is within a small tolerance of it.
     void ClosedLoopCommandServoJoint(std::vector<double> waypoint);
 
+    // Error handling
+    void HandleError(BCAP_HRESULT error_code, const char* error_description);
+
     // Utility functions
     const char* CommandFromVector(std::vector<double> q);
     std::vector<double> VectorFromVNT(BCAP_VARIANT vnt0);

--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -106,8 +106,17 @@ public:
     void bCapGetRobot();
     void bCapReleaseRobot();
 
-    // Read functions
+    //// Read functions
+    // Populates joint_positions with the current joint values.
+    // joint_positions is mutated into a vector of 8 doubles.
+    // The first 6 values are the joint angles in degrees, and the last 2
+    // values are the positions of the auxiliary axes, or 0 if they are not
+    // used.
     BCAP_HRESULT GetCurJnt(std::vector<double>& joint_positions);
+    // Populates force_values with the current force values.
+    // force_values is mutated into a vector of 6 doubles.
+    // The first 3 values are the force values in Newtons, and the last 3
+    // values are the torque values in Newton-meters.
     BCAP_HRESULT GetForceValue(std::vector<double>& force_values);
     // TODO: Change this function signature to match the Denso b-CAP API.
     std::tuple<BCAP_HRESULT, std::vector<double>> GetMountingCalib(const char* work_coordinate);
@@ -144,6 +153,7 @@ public:
     BCAP_HRESULT SlvChangeMode(const char* mode);
     BCAP_HRESULT SlvMove(BCAP_VARIANT* pose, BCAP_VARIANT* result);
 
+    // Resets the force sensor.
     BCAP_HRESULT ForceSensor(const char* mode);
 };
 
@@ -173,9 +183,20 @@ public:
     std::string GetErrorDescription(BCAP_HRESULT error_code);
 
     // High level commands
-    // Returns a tuple containing the error code and the joint positions in radians.
+    // Returns a tuple containing the error code and the joint positions in
+    // radians.
     std::tuple<BCAP_HRESULT, std::vector<double>> GetJointPositions();
     // Executes a trajectory of joint angles in radians.
+    // total_force_limit, total_torque_limit, and per_axis_force_torque_limits
+    // describe stopping criteria for trajectory execution based on force
+    // sensing. If any of the following are true, then trajectory execution is
+    // stopped early:
+    //   1. If the total force exceeds total_force_limit N,
+    //   2. If the total torque exceeds total_torque_limit Nm, or
+    //   3. If the force or torque on any axis exceeds the corresponding limit
+    //     in per_axis_force_torque_limits.
+    // The return value is true if the trajectory fully executed, and false if
+    // it was stopped early.
     bool ExecuteServoTrajectory(
         RobotTrajectory& traj,
         std::optional<double> total_force_limit = std::nullopt,

--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -149,7 +149,8 @@ public:
 // RAII-style mutex for the Denso arm mutex for axis control.
 // See "TakeArm" and "GiveArm" in the Cobotta Pro manual for more information
 // about the Denso arm mutex.
-// The constructor calls "TakeArm" and the destructor calls "GiveArm".
+// The constructor calls "TakeArm" and "Motor(1)", and the destructor calls
+// "GiveArm".
 class DensoArmMutex {
 public:
     DensoArmMutex(DensoReadWriteDriver &driver);

--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -201,10 +201,10 @@ public:
     // The return value is true if the trajectory fully executed, and false if
     // it was stopped early.
     bool ExecuteServoTrajectory(
-        RobotTrajectory& traj,
-        std::optional<double> total_force_limit = std::nullopt,
-        std::optional<double> total_torque_limit = std::nullopt,
-        std::optional<std::vector<double>> per_axis_force_torque_limits = std::nullopt
+        const RobotTrajectory& traj,
+        const std::optional<double> total_force_limit = std::nullopt,
+        const std::optional<double> total_torque_limit = std::nullopt,
+        const std::optional<std::vector<double>> per_axis_force_torque_limits = std::nullopt
     );
     BCAP_HRESULT SetTcpLoad(const int32_t tool_value);
     std::tuple<BCAP_HRESULT, std::vector<double>> GetMountingCalib(const char* work_coordinate);
@@ -229,14 +229,14 @@ private:
     // This function runs while force_limit_exceeded is false.
     // If the force limit is exceeded, force_limit_exceeded is set to true.
     void RunForceSensingLoop(
-        std::optional<double> total_force_limit,
-        std::optional<double> total_torque_limit,
-        std::optional<std::vector<double>> per_axis_force_torque_limits
+        const std::optional<double> total_force_limit,
+        const std::optional<double> total_torque_limit,
+        const std::optional<std::vector<double>> per_axis_force_torque_limits
     );
 
     // Repeatedly commands a joint position in slave mode until the robot's
     // current joint position is within a small tolerance of it.
-    void ClosedLoopCommandServoJoint(std::vector<double> waypoint);
+    void ClosedLoopCommandServoJoint(const std::vector<double>& waypoint);
 
     // Error handling
     void HandleError(BCAP_HRESULT error_code, const char* error_description);

--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -175,7 +175,7 @@ public:
     // Returns a tuple containing the error code and the joint positions in radians.
     std::tuple<BCAP_HRESULT, std::vector<double>> GetJointPositions();
     // Executes a trajectory of joint angles in radians.
-    void ExecuteServoTrajectory(RobotTrajectory& traj);
+    bool ExecuteServoTrajectory(RobotTrajectory& traj);
     BCAP_HRESULT SetTcpLoad(const int32_t tool_value);
     std::tuple<BCAP_HRESULT, std::vector<double>> GetMountingCalib(const char* work_coordinate);
 

--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -88,7 +88,6 @@ private:
     std::string _err_msg;
 };
 
-
 // Maintains a connection to a Denso RC9 controller and provides wrapper
 // functions for common "read-only" operations, which do not change the
 // state of the controller.

--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -181,7 +181,12 @@ public:
 
     int current_waypoint_index;
 
-    // TODO: Make this variable private.
+private:
+    // Denso b-CAP drivers, one for read-only operations and one for read-write
+    // operations.
+    DensoReadDriver read_driver;
+    DensoReadWriteDriver write_driver;
+
     // The purpose of this variable is two-fold:
     //   1. The RunForceSensingLoop function only runs while this variable is
     //      false.
@@ -189,7 +194,6 @@ public:
     //      force limit is exceeded.
     std::atomic<bool> force_limit_exceeded;
 
-    // TODO: Make this function private.
     // Runs force sensing loop with the read-only Denso driver. Should be used
     // in a separate thread.
     // This function runs while force_limit_exceeded is false.
@@ -199,13 +203,6 @@ public:
         double total_torque_limit,
         std::vector<double> per_axis_force_torque_limits
     );
-
-private:
-    // Denso b-CAP drivers, one for read-only operations and one for read-write
-    // operations.
-    DensoReadDriver read_driver;
-    DensoReadWriteDriver write_driver;
-
 
     // Repeatedly commands a joint position in slave mode until the robot's
     // current joint position is within a small tolerance of it.

--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -99,6 +99,8 @@ public:
     void Start();
     void Stop();
 
+    BCAP_HRESULT ClearError();
+
     //// Read functions
     // Populates joint_positions with the current joint values.
     // joint_positions is mutated into a vector of 8 doubles.
@@ -140,7 +142,6 @@ class DensoReadWriteDriver : public DensoReadDriver {
 public:
     DensoReadWriteDriver();
 
-    BCAP_HRESULT ClearError();
     BCAP_HRESULT ManualReset();
     BCAP_HRESULT Motor(bool command);
     BCAP_HRESULT TakeArm();

--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -13,6 +13,7 @@
 #include <cassert>
 #include <vector>
 #include <tuple>
+#include <atomic>
 
 #define DEFAULT_SERVER_IP_ADDRESS    "192.168.0.1"
 #define DEFAULT_SERVER_PORT_NUM      5007
@@ -149,12 +150,10 @@ public:
         std::vector<double> tcpForceTorqueLimit
     );
 
-private:
     // The purpose of this variable is two-fold:
     //   1. The _runForceSensingLoop function only runs while this variable is false.
     //   2. The _runForceSensingLoop function sets this variable to true if the force limit is exceeded.
-    std::atomic<bool> _force_limit_exceeded;
-
+    std::atomic<bool> force_limit_exceeded;
 };
 
 

--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -140,20 +140,21 @@ public:
 
     int current_waypoint_index;
 
+    // Runs force sensing loop. Should be used in a separate thread.
+    // This function runs while _force_limit_exceeded is false.
+    // If the force limit is exceeded, _force_limit_exceeded is set to true.
+    void runForceSensingLoop(
+        double totalForceLimit,
+        double totalTorqueLimit,
+        std::vector<double> tcpForceTorqueLimit
+    );
+
 private:
     // The purpose of this variable is two-fold:
     //   1. The _runForceSensingLoop function only runs while this variable is false.
     //   2. The _runForceSensingLoop function sets this variable to true if the force limit is exceeded.
     std::atomic<bool> _force_limit_exceeded;
 
-    // Runs force sensing loop. Should be used in a separate thread.
-    // This function runs while _force_limit_exceeded is false.
-    // If the force limit is exceeded, _force_limit_exceeded is set to true.
-    void _runForceSensingLoop(
-        double totalForceLimit,
-        double totalTorqueLimit,
-        std::vector<double> tcpForceTorqueLimit
-    );
 };
 
 

--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -96,14 +96,8 @@ public:
     DensoReadDriver();
 
     // Setup and teardown functions
-    void bCapOpen();
-    void bCapClose();
-    void bCapServiceStart();
-    void bCapServiceStop();
-    void bCapControllerConnect();
-    void bCapControllerDisconnect();
-    void bCapGetRobot();
-    void bCapReleaseRobot();
+    void Start();
+    void Stop();
 
     //// Read functions
     // Populates joint_positions with the current joint values.
@@ -128,6 +122,16 @@ protected:
     int iSockFD;
     uint32_t lhController;
     uint32_t lhRobot;
+
+    // Setup and teardown functions
+    void bCapOpen();
+    void bCapClose();
+    void bCapServiceStart();
+    void bCapServiceStop();
+    void bCapControllerConnect();
+    void bCapControllerDisconnect();
+    void bCapGetRobot();
+    void bCapReleaseRobot();
 };
 
 // Inherits from DensoReadDriver and adds wrapper functions for "write"

--- a/medra_pybind/include/filter.hpp
+++ b/medra_pybind/include/filter.hpp
@@ -1,5 +1,6 @@
 #include <vector>
 #include <queue>
+#include <stdexcept>
 
 namespace filter {
 

--- a/medra_pybind/include/filter.hpp
+++ b/medra_pybind/include/filter.hpp
@@ -1,0 +1,25 @@
+#include <vector>
+#include <queue>
+
+namespace filter {
+
+// Filters a stream of double-vectors by calculating the mean of the last
+// window_size values. The vectors must all have the same length of
+// measurement_size.
+class MeanFilter {
+    public:
+        MeanFilter(const size_t window_size, const size_t measurement_size);
+        void AddValue(std::vector<double> new_value);
+        std::vector<double> GetMean();
+
+    private:
+        const size_t window_size;
+        const size_t measurement_size;
+        size_t window_count;  // Number of values in the window.
+
+        // Stores the sum of values in the window.
+        std::queue<std::vector<double>> window;
+        std::vector<double> sum_vector;
+    };
+
+}  // end namespace filter

--- a/medra_pybind/include/filter.hpp
+++ b/medra_pybind/include/filter.hpp
@@ -18,8 +18,9 @@ class MeanFilter {
         const size_t measurement_size;
         size_t window_count;  // Number of values in the window.
 
-        // Stores the sum of values in the window.
+        // Stores the last window_size values.
         std::queue<std::vector<double>> window;
+        // Stores the sum of values in the window.
         std::vector<double> sum_vector;
     };
 

--- a/medra_pybind/pyproject.toml
+++ b/medra_pybind/pyproject.toml
@@ -10,4 +10,4 @@ build-dir = "build"
 
 [project]
 name = "medra_bcap"
-version = "0.1.6"
+version = "0.1.7"

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -153,6 +153,14 @@ namespace denso_controller
         }
     }
 
+    BCAP_HRESULT DensoReadDriver::ClearError()
+    {
+        long lResult;
+        BCAP_HRESULT hr = bCap_ControllerExecute(
+            iSockFD, lhController, "ClearError", "", &lResult);
+        return hr;
+    }
+
     BCAP_HRESULT DensoReadDriver::GetCurJnt(std::vector<double> &joint_positions)
     {
         double dJnt[8];
@@ -165,6 +173,7 @@ namespace denso_controller
                 break;
             }
             SPDLOG_WARN("Failed to get joint pos, attempt ", std::to_string(attempt));
+            ClearError();
         }
         if (FAILED(hr))
         {
@@ -192,6 +201,7 @@ namespace denso_controller
                 break;
             }
             SPDLOG_WARN("Failed to get force value, attempt ", std::to_string(attempt));
+            ClearError();
         }
         if (FAILED(hr))
         {
@@ -260,13 +270,6 @@ namespace denso_controller
         session_name = "write";
     }
 
-    BCAP_HRESULT DensoReadWriteDriver::ClearError()
-    {
-        long lResult;
-        BCAP_HRESULT hr = bCap_ControllerExecute(
-            iSockFD, lhController, "ClearError", "", &lResult);
-        return hr;
-    }
 
     BCAP_HRESULT DensoReadWriteDriver::ManualReset()
     {

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -1,7 +1,7 @@
 /**
  * C++ Wrapper around Denso b-CAP library
  * Based on https://github.com/quangounet/denso/blob/master/cpp/src/DensoController.cpp
- */ 
+ */
 
 #include "b-Cap.h"
 #include "DensoController.hpp"
@@ -24,771 +24,863 @@
 #include <string.h>
 #include <cstdio>
 
+namespace denso_controller
+{
 
-namespace denso_controller {
-
-DensoArmMutex::DensoArmMutex(DensoReadWriteDriver &driver) : driver(driver) {
-    driver.TakeArm();
-    driver.Motor(true);
-}
-
-DensoArmMutex::~DensoArmMutex() {
-    driver.GiveArm();
-}
-
-
-DensoReadDriver::DensoReadDriver() {
-    server_ip_address = DEFAULT_SERVER_IP_ADDRESS;
-    server_port_num = DEFAULT_SERVER_PORT_NUM;
-    iSockFD = 0;
-    lhController = 0;
-    lhRobot = 0;
-
-    session_name = "read-only";
-}
-
-void DensoReadDriver::bCapOpen() {
-    SPDLOG_INFO("Initialize and start b-CAP.");
-    BCAP_HRESULT hr = bCap_Open(server_ip_address, server_port_num, &iSockFD);
-    if FAILED(hr) {
-        throw bCapException("\033[1;31mbCap_Open failed.\033[0m");
+    DensoArmMutex::DensoArmMutex(DensoReadWriteDriver &driver) : driver(driver)
+    {
+        driver.TakeArm();
+        driver.Motor(true);
     }
-}
 
-void DensoReadDriver::bCapClose() {
-    SPDLOG_INFO("Stop b-CAP.");
-    BCAP_HRESULT hr = bCap_Close(iSockFD);
-    if FAILED(hr) {
-        throw bCapException("\033[1;31mbCap_Close failed.\033[0m");
+    DensoArmMutex::~DensoArmMutex()
+    {
+        driver.GiveArm();
     }
-}
 
+    DensoReadDriver::DensoReadDriver()
+    {
+        server_ip_address = DEFAULT_SERVER_IP_ADDRESS;
+        server_port_num = DEFAULT_SERVER_PORT_NUM;
+        iSockFD = 0;
+        lhController = 0;
+        lhRobot = 0;
 
-void DensoReadDriver::bCapServiceStart() {
-    SPDLOG_INFO("Start b-CAP service.");
-    BCAP_HRESULT hr = bCap_ServiceStart(iSockFD);
-    if FAILED(hr) {
-        throw bCapException("\033[1;31mbCap_ServiceStart failed.\033[0m");
+        session_name = "read-only";
     }
-}
 
-void DensoReadDriver::bCapServiceStop() {
-    SPDLOG_INFO("Stop b-CAP service.");
-    BCAP_HRESULT hr = bCap_ServiceStop(iSockFD);
-    if FAILED(hr) {
-        throw bCapException("\033[1;31mbCap_ServiceStop failed.\033[0m");
-    }
-}
-
-void DensoReadDriver::bCapControllerConnect() {
-    SPDLOG_INFO("Getting controller handle. Server ip address: " + std::string(server_ip_address));
-    BCAP_HRESULT hr = bCap_ControllerConnect(iSockFD, session_name, "caoProv.DENSO.VRC9", server_ip_address, "", &lhController);
-    if FAILED(hr) {
-        throw bCapException("\033[1;31mbCap_ControllerConnect failed.\033[0m");
-    }
-}
-
-void DensoReadDriver::bCapControllerDisconnect() {
-    SPDLOG_INFO("Release controller handle.");
-    BCAP_HRESULT hr = bCap_ControllerDisconnect(iSockFD, lhController);
-    if FAILED(hr) {
-        throw bCapException("\033[1;31mbCap_ControllerDisconnect failed.\033[0m");
-    }
-}
-
-void DensoReadDriver::bCapGetRobot() {
-    SPDLOG_INFO("Get robot handle.");
-    BCAP_HRESULT hr = bCap_ControllerGetRobot(iSockFD, lhController, "Arm", "", &lhRobot);
-    if FAILED(hr) {
-        throw bCapException("\033[1;31mbCap_ControllerGetRobot failed.\033[0m");
-    }
-}
-
-void DensoReadDriver::bCapReleaseRobot() {
-    SPDLOG_INFO("Release robot handle.");
-    BCAP_HRESULT hr = bCap_RobotRelease(iSockFD, lhRobot);
-    if FAILED(hr) {
-        throw bCapException("\033[1;31mbCap_RobotRelease failed.\033[0m");
-    }
-}
-
-BCAP_HRESULT DensoReadDriver::GetCurJnt(std::vector<double>& joint_positions) {
-    double dJnt[8];
-    BCAP_HRESULT hr;
-    for (size_t attempt = 0; attempt < 3; ++attempt) {
-        hr = bCap_RobotExecute(iSockFD, lhRobot, "CurJnt", "", &dJnt);
-        if (SUCCEEDED(hr)) {
-            break;
+    void DensoReadDriver::bCapOpen()
+    {
+        SPDLOG_INFO("Initialize and start b-CAP.");
+        BCAP_HRESULT hr = bCap_Open(server_ip_address, server_port_num, &iSockFD);
+        if FAILED (hr)
+        {
+            throw bCapException("\033[1;31mbCap_Open failed.\033[0m");
         }
-        SPDLOG_WARN("Failed to get joint pos, attempt ", std::to_string(attempt));
     }
-    if (FAILED(hr)) {
-        SPDLOG_ERROR("Failed to get current joint values.");
+
+    void DensoReadDriver::bCapClose()
+    {
+        SPDLOG_INFO("Stop b-CAP.");
+        BCAP_HRESULT hr = bCap_Close(iSockFD);
+        if FAILED (hr)
+        {
+            throw bCapException("\033[1;31mbCap_Close failed.\033[0m");
+        }
+    }
+
+    void DensoReadDriver::bCapServiceStart()
+    {
+        SPDLOG_INFO("Start b-CAP service.");
+        BCAP_HRESULT hr = bCap_ServiceStart(iSockFD);
+        if FAILED (hr)
+        {
+            throw bCapException("\033[1;31mbCap_ServiceStart failed.\033[0m");
+        }
+    }
+
+    void DensoReadDriver::bCapServiceStop()
+    {
+        SPDLOG_INFO("Stop b-CAP service.");
+        BCAP_HRESULT hr = bCap_ServiceStop(iSockFD);
+        if FAILED (hr)
+        {
+            throw bCapException("\033[1;31mbCap_ServiceStop failed.\033[0m");
+        }
+    }
+
+    void DensoReadDriver::bCapControllerConnect()
+    {
+        SPDLOG_INFO("Getting controller handle. Server ip address: " + std::string(server_ip_address));
+        BCAP_HRESULT hr = bCap_ControllerConnect(iSockFD, session_name, "caoProv.DENSO.VRC9", server_ip_address, "", &lhController);
+        if FAILED (hr)
+        {
+            throw bCapException("\033[1;31mbCap_ControllerConnect failed.\033[0m");
+        }
+    }
+
+    void DensoReadDriver::bCapControllerDisconnect()
+    {
+        SPDLOG_INFO("Release controller handle.");
+        BCAP_HRESULT hr = bCap_ControllerDisconnect(iSockFD, lhController);
+        if FAILED (hr)
+        {
+            throw bCapException("\033[1;31mbCap_ControllerDisconnect failed.\033[0m");
+        }
+    }
+
+    void DensoReadDriver::bCapGetRobot()
+    {
+        SPDLOG_INFO("Get robot handle.");
+        BCAP_HRESULT hr = bCap_ControllerGetRobot(iSockFD, lhController, "Arm", "", &lhRobot);
+        if FAILED (hr)
+        {
+            throw bCapException("\033[1;31mbCap_ControllerGetRobot failed.\033[0m");
+        }
+    }
+
+    void DensoReadDriver::bCapReleaseRobot()
+    {
+        SPDLOG_INFO("Release robot handle.");
+        BCAP_HRESULT hr = bCap_RobotRelease(iSockFD, lhRobot);
+        if FAILED (hr)
+        {
+            throw bCapException("\033[1;31mbCap_RobotRelease failed.\033[0m");
+        }
+    }
+
+    BCAP_HRESULT DensoReadDriver::GetCurJnt(std::vector<double> &joint_positions)
+    {
+        double dJnt[8];
+        BCAP_HRESULT hr;
+        for (size_t attempt = 0; attempt < 3; ++attempt)
+        {
+            hr = bCap_RobotExecute(iSockFD, lhRobot, "CurJnt", "", &dJnt);
+            if (SUCCEEDED(hr))
+            {
+                break;
+            }
+            SPDLOG_WARN("Failed to get joint pos, attempt ", std::to_string(attempt));
+        }
+        if (FAILED(hr))
+        {
+            SPDLOG_ERROR("Failed to get current joint values.");
+            return hr;
+        }
+
+        joint_positions.resize(0);
+        for (int i = 0; i < 8; i++)
+        {
+            joint_positions.push_back(dJnt[i]);
+        }
         return hr;
     }
 
-    joint_positions.resize(0);
-    for (int i = 0; i < 8; i++) {
-        joint_positions.push_back(dJnt[i]);
-    }
-    return hr;
-}
-
-BCAP_HRESULT DensoReadDriver::GetForceValue(std::vector<double>& force_values) {
-    double dForce[6];
-    BCAP_HRESULT hr;
-    for (size_t attempt = 0; attempt < 3; ++attempt) {
-        hr = bCap_RobotExecute(iSockFD, lhRobot, "forceValue", "13", &dForce);
-        if SUCCEEDED(hr) {
-            break;
+    BCAP_HRESULT DensoReadDriver::GetForceValue(std::vector<double> &force_values)
+    {
+        double dForce[6];
+        BCAP_HRESULT hr;
+        for (size_t attempt = 0; attempt < 3; ++attempt)
+        {
+            hr = bCap_RobotExecute(iSockFD, lhRobot, "forceValue", "13", &dForce);
+            if SUCCEEDED (hr)
+            {
+                break;
+            }
+            SPDLOG_WARN("Failed to get force value, attempt ", std::to_string(attempt));
         }
-        SPDLOG_WARN("Failed to get force value, attempt ", std::to_string(attempt));
-    }
-    if (FAILED(hr)) {
-        SPDLOG_ERROR("Failed to get current force values.");
+        if (FAILED(hr))
+        {
+            SPDLOG_ERROR("Failed to get current force values.");
+            return hr;
+        }
+
+        force_values.resize(0);
+        for (int i = 0; i < 6; i++)
+        {
+            force_values.push_back(dForce[i]);
+        }
         return hr;
     }
 
-    force_values.resize(0);
-    for (int i = 0; i < 6; i++) {
-        force_values.push_back(dForce[i]);
-    }
-    return hr;
-}
+    std::tuple<BCAP_HRESULT, std::vector<double>>
+    DensoReadDriver::GetMountingCalib(const char *work_coordinate)
+    {
+        double work_def[8]; // Should this be 6?
+        std::vector<double> mounting_calib = std::vector<double>(8);
 
-std::tuple<BCAP_HRESULT, std::vector<double>>
-DensoReadDriver::GetMountingCalib(const char* work_coordinate) {
-    double work_def[8]; // Should this be 6?
-    std::vector<double> mounting_calib = std::vector<double>(8);
+        BCAP_HRESULT hr = bCap_RobotExecute(iSockFD, lhRobot, "getWorkDef", work_coordinate, &work_def);
+        if FAILED (hr)
+        {
+            SPDLOG_ERROR("Failed to get mounting calibration");
+            return {hr, mounting_calib};
+        }
 
-    BCAP_HRESULT hr = bCap_RobotExecute(iSockFD, lhRobot, "getWorkDef", work_coordinate, &work_def);
-    if FAILED(hr) {
-        SPDLOG_ERROR("Failed to get mounting calibration");
+        mounting_calib.resize(0);
+        for (int i = 0; i < 8; i++)
+        {
+            mounting_calib.push_back(work_def[i]);
+        }
+        SPDLOG_INFO("Got Mounting Calibration: (" + std::to_string(mounting_calib[0]) + ", " + std::to_string(mounting_calib[1]) + ", " + std::to_string(mounting_calib[2]) + ", " + std::to_string(mounting_calib[3]) + ", " + std::to_string(mounting_calib[4]) + ", " + std::to_string(mounting_calib[5]) + ")");
         return {hr, mounting_calib};
     }
 
-    mounting_calib.resize(0);
-    for (int i = 0; i < 8; i++) {
-        mounting_calib.push_back(work_def[i]);
+    std::string DensoReadDriver::GetErrorDescription(BCAP_HRESULT error_code)
+    {
+        char err_code_str[32];
+        sprintf(err_code_str, "%d", error_code);
+        // Denso defined local receive buffer LOCALRECBUFFER_SZ = 1024
+        char error_description[1024] = {0};
+
+        BCAP_HRESULT hr = bCap_ControllerExecute(
+            iSockFD,
+            lhController,
+            "GetErrorDescription",
+            err_code_str,
+            error_description);
+        if FAILED (hr)
+        {
+            return "Failed to get error description";
+        }
+        return std::string(error_description);
     }
-    SPDLOG_INFO("Got Mounting Calibration: (" + std::to_string(mounting_calib[0]) + ", " 
-                                               + std::to_string(mounting_calib[1]) + ", " 
-                                               + std::to_string(mounting_calib[2]) + ", " 
-                                               + std::to_string(mounting_calib[3]) + ", " 
-                                               + std::to_string(mounting_calib[4]) + ", " 
-                                               + std::to_string(mounting_calib[5]) + ")");
-    return {hr, mounting_calib};
-}
 
-std::string DensoReadDriver::GetErrorDescription(BCAP_HRESULT error_code) {
-    char err_code_str[32];
-    sprintf(err_code_str, "%d", error_code);
-    // Denso defined local receive buffer LOCALRECBUFFER_SZ = 1024
-    char error_description[1024] = {0};
+    DensoReadWriteDriver::DensoReadWriteDriver()
+    {
+        server_ip_address = DEFAULT_SERVER_IP_ADDRESS;
+        server_port_num = DEFAULT_SERVER_PORT_NUM;
+        iSockFD = 0;
+        lhController = 0;
+        lhRobot = 0;
 
-    BCAP_HRESULT hr = bCap_ControllerExecute(
-        iSockFD,
-        lhController,
-        "GetErrorDescription",
-        err_code_str,
-        error_description
-    );
-    if FAILED(hr) {
-        return "Failed to get error description";
+        session_name = "write";
     }
-    return std::string(error_description);
-}
 
-DensoReadWriteDriver::DensoReadWriteDriver() {
-    server_ip_address = DEFAULT_SERVER_IP_ADDRESS;
-    server_port_num = DEFAULT_SERVER_PORT_NUM;
-    iSockFD = 0;
-    lhController = 0;
-    lhRobot = 0;
-
-    session_name = "write";
-}
-
-BCAP_HRESULT DensoReadWriteDriver::ClearError() {
-    long lResult;
-    BCAP_HRESULT hr = bCap_ControllerExecute(
-        iSockFD, lhController, "ClearError", "", &lResult
-    );
-    return hr;
-}
-
-BCAP_HRESULT DensoReadWriteDriver::ManualReset() {
-    long lResult;
-    BCAP_HRESULT hr = bCap_ControllerExecute(
-        iSockFD, lhController, "ManualReset", "", &lResult
-    );
-    if SUCCEEDED(hr) {
-        SPDLOG_INFO("Executed Manual Reset");
-    }
-    return hr;
-}
-
-BCAP_HRESULT DensoReadWriteDriver::Motor(bool command) {
-    BCAP_HRESULT hr;
-    long lResult;
-    if (command) {
-        SPDLOG_INFO("Turn motor on.");
-        hr = bCap_RobotExecute(iSockFD, lhRobot, "Motor", "1", &lResult);
-    }
-    else {
-        SPDLOG_INFO("Turn motor off.");
-        hr = bCap_RobotExecute(iSockFD, lhRobot, "Motor", "0", &lResult);
-    }
-    return hr;
-}
-
-BCAP_HRESULT DensoReadWriteDriver::TakeArm() {
-    long lResult;
-    SPDLOG_INFO("Take arm.");
-    return bCap_RobotExecute(iSockFD, lhRobot, "TakeArm", "", &lResult);
-}
-
-BCAP_HRESULT DensoReadWriteDriver::GiveArm() {
-    long lResult;
-    SPDLOG_INFO("Give arm.");
-    return bCap_RobotExecute(iSockFD, lhRobot, "GiveArm", "", &lResult);
-}
-
-BCAP_HRESULT DensoReadWriteDriver::SetExtSpeed(const char* speed) {
-    long lResult;
-    BCAP_HRESULT hr = bCap_RobotExecute(iSockFD, lhRobot, "ExtSpeed", speed, &lResult);
-    if SUCCEEDED(hr) {
-        SPDLOG_INFO("External speed is set to " + std::string(speed));
-    }
-    return hr;
-}
-
-BCAP_HRESULT DensoReadWriteDriver::SetTcpLoad(const int32_t tool_value) {
-    // Our Robotiq grippers
-    // tool_value = 1; // ROBOTIQ_2F85_GRIPPER_PAYLOAD
-    // tool_value = 2; // ROBOTIQ_2F140_GRIPPER_PAYLOAD
-    long lValue = tool_value;
-    auto arm_mutex = DensoArmMutex(*this);
-
-    BCAP_HRESULT hr = BCAP_S_OK;
-    uint32_t lhVar;
-    hr = bCap_RobotGetVariable(iSockFD, lhRobot, "@CURRENT_TOOL", "", &lhVar);  /* Get var handle */
-    if FAILED(hr) {
-        SPDLOG_ERROR("Set TCP Load failed to get @CURRENT_TOOL variable");
+    BCAP_HRESULT DensoReadWriteDriver::ClearError()
+    {
+        long lResult;
+        BCAP_HRESULT hr = bCap_ControllerExecute(
+            iSockFD, lhController, "ClearError", "", &lResult);
         return hr;
     }
 
-    hr = bCap_VariablePutValue(iSockFD, lhVar, VT_I4, 1, &lValue);  /* Put Value */
-    if FAILED(hr) {
-        SPDLOG_ERROR("Set TCP Load failed to put value");
-    }
-
-    hr = bCap_VariableRelease(iSockFD, lhVar);	/* Release var handle*/
-    if FAILED(hr) {
-        SPDLOG_ERROR("Set TCP Load failed to release variable");
-    }
-
-    return hr;
-}
-
-BCAP_HRESULT DensoReadWriteDriver::SlvChangeMode(const char* mode) {
-    long lResult;
-    BCAP_HRESULT hr = bCap_RobotExecute(iSockFD, lhRobot, "slvChangeMode", mode, &lResult);
-    if FAILED(hr) {
-        throw bCapException("\033[1;31mbCap_SlvChangeMode failed.\033[0m");
-    }
-    return hr;
-}
-
-
-BCAP_HRESULT DensoReadWriteDriver::SlvMove(BCAP_VARIANT* pose, BCAP_VARIANT* result) {
-    BCAP_HRESULT hr;
-    for (size_t attempt = 0; attempt < 3; ++attempt) {
-        hr = bCap_RobotExecute2(iSockFD, lhRobot, "slvMove", pose, result);
-        if (SUCCEEDED(hr)) {
-            break;
+    BCAP_HRESULT DensoReadWriteDriver::ManualReset()
+    {
+        long lResult;
+        BCAP_HRESULT hr = bCap_ControllerExecute(
+            iSockFD, lhController, "ManualReset", "", &lResult);
+        if SUCCEEDED (hr)
+        {
+            SPDLOG_INFO("Executed Manual Reset");
         }
-        SPDLOG_WARN("Failed to execute slvMove, attempt ", std::to_string(attempt));
+        return hr;
     }
-    if (FAILED(hr)) {
-        SPDLOG_ERROR("Failed to execute b-CAP slave move.");
-    }
-    return hr;
-}
 
-BCAP_HRESULT DensoReadWriteDriver::ForceSensor(const char* mode) {
-    long lResult;
-    BCAP_HRESULT hr;
-    for (size_t attempt = 0; attempt < 3; ++attempt) {
-        hr = bCap_RobotExecute(iSockFD, lhRobot, "ForceSensor", mode, &lResult);
-        if (SUCCEEDED(hr)) {
-            break;
+    BCAP_HRESULT DensoReadWriteDriver::Motor(bool command)
+    {
+        BCAP_HRESULT hr;
+        long lResult;
+        if (command)
+        {
+            hr = bCap_RobotExecute(iSockFD, lhRobot, "Motor", "1", &lResult);
         }
-        SPDLOG_WARN("Failed to execute ForceSensor; attempt ", std::to_string(attempt));
-        sleep(0.001);
-    }
-    if FAILED(hr) {
-        SPDLOG_ERROR("Failed to execute ForceSensor.");
-    }
-    return hr;
-}
-
-
-DensoController::DensoController() :
-    read_driver(DensoReadDriver()),
-    write_driver(DensoReadWriteDriver())
-{
-    current_waypoint_index = 0;
-}
-
-void DensoController::Start() {
-    read_driver.bCapOpen();
-    SPDLOG_INFO("b-Cap port opened for read driver");
-    read_driver.bCapServiceStart();
-    SPDLOG_INFO("b-Cap service started for read driver");
-    read_driver.bCapControllerConnect();
-    SPDLOG_INFO("Connected to controller for read driver");
-    read_driver.bCapGetRobot();
-    SPDLOG_INFO("Obtained robot handle for read driver");
-
-    write_driver.bCapOpen();
-    SPDLOG_INFO("b-Cap port opened for write driver");
-    write_driver.bCapServiceStart();
-    SPDLOG_INFO("b-Cap service started for write driver");
-    write_driver.bCapControllerConnect();
-    SPDLOG_INFO("Connected to controller for write driver");
-    write_driver.bCapGetRobot();
-    SPDLOG_INFO("Obtained robot handle for write driver");
-
-    BCAP_HRESULT hr;
-
-    hr = ClearError();
-    if FAILED(hr) {
-        HandleError(hr, "ClearError failed.");
+        else
+        {
+            hr = bCap_RobotExecute(iSockFD, lhRobot, "Motor", "0", &lResult);
+        }
+        return hr;
     }
 
-    hr = write_driver.ManualReset();
-    if FAILED(hr) {
-        HandleError(hr, "ManualReset failed.");
+    BCAP_HRESULT DensoReadWriteDriver::TakeArm()
+    {
+        long lResult;
+        return bCap_RobotExecute(iSockFD, lhRobot, "TakeArm", "", &lResult);
     }
 
-    // Set the external speed to 100%
-    hr = write_driver.SetExtSpeed("100");
-    if FAILED(hr) {
-        HandleError(hr, "SetExtSpeed failed.");
+    BCAP_HRESULT DensoReadWriteDriver::GiveArm()
+    {
+        long lResult;
+        return bCap_RobotExecute(iSockFD, lhRobot, "GiveArm", "", &lResult);
     }
 
-    auto arm_mutex = DensoArmMutex(write_driver);
-    hr = write_driver.Motor(true);
-    if FAILED(hr) {
-        HandleError(hr, "MotorOn failed.");
+    BCAP_HRESULT DensoReadWriteDriver::SetExtSpeed(const char *speed)
+    {
+        long lResult;
+        BCAP_HRESULT hr = bCap_RobotExecute(iSockFD, lhRobot, "ExtSpeed", speed, &lResult);
+        if SUCCEEDED (hr)
+        {
+            SPDLOG_INFO("External speed is set to " + std::string(speed));
+        }
+        return hr;
     }
-    current_waypoint_index = 0;
-}
 
-void DensoController::Stop() {
-    force_limit_exceeded = true;
+    BCAP_HRESULT DensoReadWriteDriver::SetTcpLoad(const int32_t tool_value)
+    {
+        // Our Robotiq grippers
+        // tool_value = 1; // ROBOTIQ_2F85_GRIPPER_PAYLOAD
+        // tool_value = 2; // ROBOTIQ_2F140_GRIPPER_PAYLOAD
+        long lValue = tool_value;
+        auto arm_mutex = DensoArmMutex(*this);
 
-    read_driver.bCapReleaseRobot();
-    read_driver.bCapControllerDisconnect();
-    read_driver.bCapServiceStop();
-    read_driver.bCapClose();
-
-    write_driver.bCapReleaseRobot();
-    write_driver.bCapControllerDisconnect();
-    write_driver.bCapServiceStop();
-    write_driver.bCapClose();
-}
-
-BCAP_HRESULT DensoController::ClearError() {
-    return write_driver.ClearError();
-}
-
-std::string DensoController::GetErrorDescription(BCAP_HRESULT error_code) {
-    return read_driver.GetErrorDescription(error_code);
-}
-
-BCAP_HRESULT DensoController::SetTcpLoad(const int32_t tool_value) {
-    return write_driver.SetTcpLoad(tool_value);
-}
-
-std::tuple<BCAP_HRESULT, std::vector<double>>
-DensoController::GetMountingCalib(const char* work_coordinate) {
-    return read_driver.GetMountingCalib(work_coordinate);
-}
-
-std::tuple<BCAP_HRESULT, std::vector<double>>
-DensoController::GetJointPositions() {
-    std::vector<double> joint_positions;
-    BCAP_HRESULT hr = read_driver.GetCurJnt(joint_positions);
-
-    // Convert joint positions to radians
-    for (int i = 0; i < joint_positions.size(); i++) {
-        joint_positions[i] = Deg2Rad(joint_positions[i]);
-    }
-    return {hr, joint_positions};
-}
-
-
-bool DensoController::ExecuteServoTrajectory(
-    RobotTrajectory& traj,
-    std::optional<double> total_force_limit,
-    std::optional<double> total_torque_limit,
-    std::optional<std::vector<double>> per_axis_force_torque_limits
-)
-{
-    bool trajectory_execution_finished = true;
-    BCAP_HRESULT hr;
-    long lResult;
-
-    auto arm_mutex = DensoArmMutex(write_driver);
-
-    // Reset the force sensor to prevent drift in the force readings.
-    // Do it here, instead of in the force sensing thread, because this call
-    // requires the arm mutex.
-    hr = write_driver.ForceSensor("0");
-
-    // Start a thread to stream force sensor data, setting the
-    force_limit_exceeded = false;
-    std::thread force_sensing_thread(
-        &DensoController::RunForceSensingLoop,
-        this,
-        total_force_limit,
-        total_torque_limit,
-        per_axis_force_torque_limits
-    );
-
-    // Enter slave mode
-    hr = write_driver.SlvChangeMode(SERVO_MODE_ON);
-    if (FAILED(hr)) {
-        std::string err_description = GetErrorDescription(hr);
-        SPDLOG_ERROR("Failed to enter b-CAP slave mode." + err_description);
-        throw EnterSlaveModeException(err_description);
-    }
-    SPDLOG_INFO("Slave mode ON");
-
-    // Execute the trajectory
-    BCAP_VARIANT vntPose, vntReturn;
-    for (size_t i = 0; i < traj.size(); i++) {
-        // Stop if the force exceedance condition is true
-        if (force_limit_exceeded) {
-            SPDLOG_INFO("Force limit exceeded. Stopping trajectory execution.");
-            trajectory_execution_finished = false;
-            break;
+        BCAP_HRESULT hr = BCAP_S_OK;
+        uint32_t lhVar;
+        hr = bCap_RobotGetVariable(iSockFD, lhRobot, "@CURRENT_TOOL", "", &lhVar); /* Get var handle */
+        if FAILED (hr)
+        {
+            SPDLOG_ERROR("Set TCP Load failed to get @CURRENT_TOOL variable");
+            return hr;
         }
 
-        current_waypoint_index = i;
-        const auto& joint_position = traj.trajectory[i];        
-        vntPose = VNTFromRadVector(joint_position);
-        hr = write_driver.SlvMove(&vntPose, &vntReturn);
-
-        if (FAILED(hr)) {
-            std::string err_description = GetErrorDescription(hr);
-            SPDLOG_ERROR("Failed to execute b-CAP slave move. " + err_description);
-            std::string msg = "Index " + std::to_string(i) + " of " + std::to_string(traj.size())
-                + " ErrDescription: " + err_description;
-            throw SlaveMoveException(msg);
+        hr = bCap_VariablePutValue(iSockFD, lhVar, VT_I4, 1, &lValue); /* Put Value */
+        if FAILED (hr)
+        {
+            SPDLOG_ERROR("Set TCP Load failed to put value");
         }
 
-        // Print the joint positions
-        // std::string msg = "slvmove (";
-        // for (int i=0; i<joint_position.size(); ++i)
-        //     msg += std::to_string(joint_position[i]) + ' ';
-        // msg += ")";
-        // SPDLOG_INFO(msg);
-    }
-
-    // Stop the force sensing thread.
-    force_limit_exceeded = true;
-    force_sensing_thread.join();
-
-    // Close loop servo commands on last waypoint
-    if (!force_limit_exceeded) {
-        ClosedLoopCommandServoJoint(traj.trajectory.back());
-    }
-
-    // SPDLOG_INFO("Exec traj done");
-
-    // Exit slave mode
-    hr = write_driver.SlvChangeMode(SERVO_MODE_OFF);
-    if (FAILED(hr)) {
-        std::string err_description = GetErrorDescription(hr);
-        SPDLOG_ERROR("Failed to exit b-CAP slave mode." + err_description);
-        throw ExitSlaveModeException(err_description);
-    }
-    SPDLOG_INFO("Slave mode OFF");
-
-    return trajectory_execution_finished;
-}
-
-void DensoController::RunForceSensingLoop(
-    std::optional<double> total_force_limit,
-    std::optional<double> total_torque_limit,
-    std::optional<std::vector<double>> per_axis_force_torque_limits
-) {
-    // Exit early if no force limits are specified
-    if (!total_force_limit.has_value()
-        && !total_torque_limit.has_value()
-        && !per_axis_force_torque_limits.has_value()
-    ) {
-        return;
-    }
-
-    const int frequency = 100; // Hz
-    const int period = 1000 / frequency; // period in milliseconds
-
-    const int filter_size = 5;
-    const int force_value_data_size = 6;  // x, y, z, rx, ry, rz
-    filter::MeanFilter mean_filter(filter_size, force_value_data_size);
-
-    std::ofstream force_sensing_log("force_sensing_log.txt", std::ios::app);
-    if (!force_sensing_log.is_open()) {
-        SPDLOG_ERROR("Failed to open force sensing log file.");
-        Stop();
-        throw bCapException("Force sensing logging failed.");
-    }
-
-    BCAP_HRESULT hr;
-    std::vector<double> force_values;
-    while (!force_limit_exceeded) {
-        auto start = std::chrono::steady_clock::now();
-
-        // Check the force threshold
-        hr = read_driver.GetForceValue(force_values);
-        if (FAILED(hr)) {
-            HandleError(hr, "GetForceValue failed.");
+        hr = bCap_VariableRelease(iSockFD, lhVar); /* Release var handle*/
+        if FAILED (hr)
+        {
+            SPDLOG_ERROR("Set TCP Load failed to release variable");
         }
-        mean_filter.AddValue(force_values);
 
-        // Use the mean of the last filter_size force values
-        force_values = mean_filter.GetMean();
+        return hr;
+    }
 
-        // Write the 6-vector data to the file
-        for (size_t i = 0; i < force_values.size(); ++i) {
-            force_sensing_log << force_values[i];
-            if (i < force_values.size() - 1) {
-                force_sensing_log << " "; // Separate values with a space
+    BCAP_HRESULT DensoReadWriteDriver::SlvChangeMode(const char *mode)
+    {
+        long lResult;
+        BCAP_HRESULT hr = bCap_RobotExecute(iSockFD, lhRobot, "slvChangeMode", mode, &lResult);
+        if FAILED (hr)
+        {
+            throw bCapException("\033[1;31mbCap_SlvChangeMode failed.\033[0m");
+        }
+        return hr;
+    }
+
+    BCAP_HRESULT DensoReadWriteDriver::SlvMove(BCAP_VARIANT *pose, BCAP_VARIANT *result)
+    {
+        BCAP_HRESULT hr;
+        for (size_t attempt = 0; attempt < 3; ++attempt)
+        {
+            hr = bCap_RobotExecute2(iSockFD, lhRobot, "slvMove", pose, result);
+            if (SUCCEEDED(hr))
+            {
+                break;
             }
+            SPDLOG_WARN("Failed to execute slvMove, attempt ", std::to_string(attempt));
         }
-        force_sensing_log << "\n"; // Newline after each vector
+        if (FAILED(hr))
+        {
+            SPDLOG_ERROR("Failed to execute b-CAP slave move.");
+        }
+        return hr;
+    }
 
-        // Check the total force does not exceed the limit
-        double total_force = std::sqrt(
-            std::pow(force_values[0], 2) + std::pow(force_values[1], 2) + std::pow(force_values[2], 2)
-        );
-        if (total_force_limit.has_value()
-            && total_force > *total_force_limit
-        ) {
-            force_limit_exceeded = true;
-            SPDLOG_INFO("Force limit exceeded. Total force: " + std::to_string(total_force));
-            break;
+    BCAP_HRESULT DensoReadWriteDriver::ForceSensor(const char *mode)
+    {
+        long lResult;
+        BCAP_HRESULT hr;
+        for (size_t attempt = 0; attempt < 3; ++attempt)
+        {
+            hr = bCap_RobotExecute(iSockFD, lhRobot, "ForceSensor", mode, &lResult);
+            if (SUCCEEDED(hr))
+            {
+                break;
+            }
+            SPDLOG_WARN("Failed to execute ForceSensor; attempt ", std::to_string(attempt));
+            sleep(0.001);
+        }
+        if FAILED (hr)
+        {
+            SPDLOG_ERROR("Failed to execute ForceSensor.");
+        }
+        return hr;
+    }
+
+    DensoController::DensoController() : read_driver(DensoReadDriver()),
+                                         write_driver(DensoReadWriteDriver())
+    {
+        current_waypoint_index = 0;
+    }
+
+    void DensoController::Start()
+    {
+        read_driver.bCapOpen();
+        SPDLOG_INFO("b-Cap port opened for read driver");
+        read_driver.bCapServiceStart();
+        SPDLOG_INFO("b-Cap service started for read driver");
+        read_driver.bCapControllerConnect();
+        SPDLOG_INFO("Connected to controller for read driver");
+        read_driver.bCapGetRobot();
+        SPDLOG_INFO("Obtained robot handle for read driver");
+
+        write_driver.bCapOpen();
+        SPDLOG_INFO("b-Cap port opened for write driver");
+        write_driver.bCapServiceStart();
+        SPDLOG_INFO("b-Cap service started for write driver");
+        write_driver.bCapControllerConnect();
+        SPDLOG_INFO("Connected to controller for write driver");
+        write_driver.bCapGetRobot();
+        SPDLOG_INFO("Obtained robot handle for write driver");
+
+        BCAP_HRESULT hr;
+
+        hr = ClearError();
+        if FAILED (hr)
+        {
+            HandleError(hr, "ClearError failed.");
         }
 
-        // Check the total torque does not exceed the limit
-        double total_torque = std::sqrt(
-            std::pow(force_values[3], 2) + std::pow(force_values[4], 2) + std::pow(force_values[5], 2)
-        );
-        if (total_torque_limit.has_value()
-            && total_torque > *total_torque_limit
-        ) {
-            force_limit_exceeded = true;
-            SPDLOG_INFO("Torque limit exceeded. Total torque: " + std::to_string(total_torque));
-            break;
+        hr = write_driver.ManualReset();
+        if FAILED (hr)
+        {
+            HandleError(hr, "ManualReset failed.");
         }
 
-        // Check the TCP force/torque does not exceed the limit
-        if (per_axis_force_torque_limits.has_value()) {
-            for (int i = 0; i < 6; i++) {
-                if (std::abs(force_values[i]) > (*per_axis_force_torque_limits)[i]) {
-                    force_limit_exceeded = true;
-                    SPDLOG_INFO("TCP force/torque limit exceeded. Force/Torque: " + std::to_string(force_values[i]));
+        // Set the external speed to 100%
+        hr = write_driver.SetExtSpeed("100");
+        if FAILED (hr)
+        {
+            HandleError(hr, "SetExtSpeed failed.");
+        }
+
+        auto arm_mutex = DensoArmMutex(write_driver);
+        hr = write_driver.Motor(true);
+        if FAILED (hr)
+        {
+            HandleError(hr, "MotorOn failed.");
+        }
+        current_waypoint_index = 0;
+    }
+
+    void DensoController::Stop()
+    {
+        force_limit_exceeded = true;
+
+        read_driver.bCapReleaseRobot();
+        read_driver.bCapControllerDisconnect();
+        read_driver.bCapServiceStop();
+        read_driver.bCapClose();
+
+        write_driver.bCapReleaseRobot();
+        write_driver.bCapControllerDisconnect();
+        write_driver.bCapServiceStop();
+        write_driver.bCapClose();
+    }
+
+    BCAP_HRESULT DensoController::ClearError()
+    {
+        return write_driver.ClearError();
+    }
+
+    std::string DensoController::GetErrorDescription(BCAP_HRESULT error_code)
+    {
+        return read_driver.GetErrorDescription(error_code);
+    }
+
+    BCAP_HRESULT DensoController::SetTcpLoad(const int32_t tool_value)
+    {
+        return write_driver.SetTcpLoad(tool_value);
+    }
+
+    std::tuple<BCAP_HRESULT, std::vector<double>>
+    DensoController::GetMountingCalib(const char *work_coordinate)
+    {
+        return read_driver.GetMountingCalib(work_coordinate);
+    }
+
+    std::tuple<BCAP_HRESULT, std::vector<double>>
+    DensoController::GetJointPositions()
+    {
+        std::vector<double> joint_positions;
+        BCAP_HRESULT hr = read_driver.GetCurJnt(joint_positions);
+
+        // Convert joint positions to radians
+        for (int i = 0; i < joint_positions.size(); i++)
+        {
+            joint_positions[i] = Deg2Rad(joint_positions[i]);
+        }
+        return {hr, joint_positions};
+    }
+
+    bool DensoController::ExecuteServoTrajectory(
+        RobotTrajectory &traj,
+        std::optional<double> total_force_limit,
+        std::optional<double> total_torque_limit,
+        std::optional<std::vector<double>> per_axis_force_torque_limits)
+    {
+        // std::cout << total_force_limit << " " << total_torque_limit << " "
+        //           << per_axis_force_torque_limits << std::endl;
+
+        bool trajectory_execution_finished = true;
+        BCAP_HRESULT hr;
+        long lResult;
+
+        auto arm_mutex = DensoArmMutex(write_driver);
+
+        // Reset the force sensor to prevent drift in the force readings.
+        // Do it here, instead of in the force sensing thread, because this call
+        // requires the arm mutex.
+        hr = write_driver.ForceSensor("0");
+
+        // Start a thread to stream force sensor data, setting the
+        force_limit_exceeded = false;
+        while (force_limit_exceeded) {
+            sleep(0.001);
+        }
+        std::thread force_sensing_thread(
+            &DensoController::RunForceSensingLoop,
+            this,
+            total_force_limit,
+            total_torque_limit,
+            per_axis_force_torque_limits);
+
+        // Enter slave mode
+        hr = write_driver.SlvChangeMode(SERVO_MODE_ON);
+        if (FAILED(hr))
+        {
+            std::string err_description = GetErrorDescription(hr);
+            SPDLOG_ERROR("Failed to enter b-CAP slave mode." + err_description);
+            throw EnterSlaveModeException(err_description);
+        }
+        SPDLOG_INFO("Slave mode ON");
+
+        // Execute the trajectory
+        BCAP_VARIANT vntPose, vntReturn;
+        for (size_t i = 0; i < traj.size(); i++)
+        {
+            // Stop if the force exceedance condition is true
+            if (force_limit_exceeded)
+            {
+                SPDLOG_INFO("Force limit exceeded after " + std::to_string(current_waypoint_index) + " waypoints. Stopping trajectory execution.");
+                trajectory_execution_finished = false;
+                break;
+            }
+
+            current_waypoint_index = i;
+            const auto &joint_position = traj.trajectory[i];
+            vntPose = VNTFromRadVector(joint_position);
+            hr = write_driver.SlvMove(&vntPose, &vntReturn);
+
+            if (FAILED(hr))
+            {
+                std::string err_description = GetErrorDescription(hr);
+                SPDLOG_ERROR("Failed to execute b-CAP slave move. " + err_description);
+                std::string msg = "Index " + std::to_string(i) + " of " + std::to_string(traj.size()) + " ErrDescription: " + err_description;
+                throw SlaveMoveException(msg);
+            }
+
+            // Print the joint positions
+            // std::string msg = "slvmove (";
+            // for (int i=0; i<joint_position.size(); ++i)
+            //     msg += std::to_string(joint_position[i]) + ' ';
+            // msg += ")";
+            // SPDLOG_INFO(msg);
+        }
+
+        // Stop the force sensing thread.
+        force_limit_exceeded = true;
+        force_sensing_thread.join();
+
+        // Close loop servo commands on last waypoint
+        if (!force_limit_exceeded)
+        {
+            ClosedLoopCommandServoJoint(traj.trajectory.back());
+        }
+
+        // SPDLOG_INFO("Exec traj done");
+
+        // Exit slave mode
+        hr = write_driver.SlvChangeMode(SERVO_MODE_OFF);
+        if (FAILED(hr))
+        {
+            std::string err_description = GetErrorDescription(hr);
+            SPDLOG_ERROR("Failed to exit b-CAP slave mode." + err_description);
+            throw ExitSlaveModeException(err_description);
+        }
+        SPDLOG_INFO("Slave mode OFF");
+
+        return trajectory_execution_finished;
+    }
+
+    void DensoController::RunForceSensingLoop(
+        std::optional<double> total_force_limit,
+        std::optional<double> total_torque_limit,
+        std::optional<std::vector<double>> per_axis_force_torque_limits)
+    {
+        // Exit early if no force limits are specified
+        if (!total_force_limit.has_value() && !total_torque_limit.has_value() && !per_axis_force_torque_limits.has_value())
+        {
+            std::cout << "Exit force sensing loop early" << std::endl;
+            return;
+        }
+
+        const int frequency = 100;           // Hz
+        const int period = 1000 / frequency; // period in milliseconds
+
+        const int filter_size = 5;
+        const int force_value_data_size = 6; // x, y, z, rx, ry, rz
+        filter::MeanFilter mean_filter(filter_size, force_value_data_size);
+
+        std::ofstream force_sensing_log("force_sensing_log.txt", std::ios::app);
+        if (!force_sensing_log.is_open())
+        {
+            SPDLOG_ERROR("Failed to open force sensing log file.");
+            Stop();
+            throw bCapException("Force sensing logging failed.");
+        }
+
+        BCAP_HRESULT hr;
+        std::vector<double> force_values;
+        while (!force_limit_exceeded)
+        {
+            auto start = std::chrono::steady_clock::now();
+
+            // Check the force threshold
+            hr = read_driver.GetForceValue(force_values);
+            if (FAILED(hr))
+            {
+                HandleError(hr, "GetForceValue failed.");
+            }
+            // SPDLOG_INFO("size of force_values 1: ", std::to_string(force_values.size()));
+            mean_filter.AddValue(force_values);
+            // SPDLOG_INFO("size of force_values 2: ", std::to_string(force_values.size()));
+
+            // Use the mean of the last filter_size force values
+            force_values = mean_filter.GetMean();
+
+            // Write the 6-vector data to the file
+            for (size_t i = 0; i < force_values.size(); ++i)
+            {
+                force_sensing_log << force_values[i];
+                if (i < force_values.size() - 1)
+                {
+                    force_sensing_log << " "; // Separate values with a space
+                }
+            }
+            force_sensing_log << "\n"; // Newline after each vector
+
+            // Check the total force does not exceed the limit
+            double total_force = std::sqrt(
+                std::pow(force_values[0], 2) + std::pow(force_values[1], 2) + std::pow(force_values[2], 2));
+            if (total_force_limit.has_value() && total_force > *total_force_limit)
+            {
+                std::cout << "Force limit exceeded. Total force: " << std::to_string(total_force) << std::endl;
+                std::cout << "Force limit: " << *total_force_limit << std::endl;
+                force_limit_exceeded = true;
+                break;
+            }
+
+            // Check the total torque does not exceed the limit
+            double total_torque = std::sqrt(
+                std::pow(force_values[3], 2) + std::pow(force_values[4], 2) + std::pow(force_values[5], 2));
+            if (total_torque_limit.has_value() && total_torque > *total_torque_limit)
+            {
+                std::cout << "Torque limit exceeded. Total torque: " << std::to_string(total_torque) << std::endl;
+                force_limit_exceeded = true;
+                break;
+            }
+
+            // Check the TCP force/torque does not exceed the limit
+            if (per_axis_force_torque_limits.has_value())
+            {
+                for (int i = 0; i < 6; i++)
+                {
+                    if (std::abs(force_values[i]) > (*per_axis_force_torque_limits)[i])
+                    {
+                        std::cout << "TCP force/torque limit exceeded. Force/Torque: " << std::to_string(force_values[i]) << std::endl;
+                        force_limit_exceeded = true;
+                        break;
+                    }
+                }
+            }
+
+            // High-precision sleep to maintain the desired frequency
+            auto end = std::chrono::steady_clock::now();
+            std::chrono::duration<double, std::milli> elapsed = end - start;
+            std::this_thread::sleep_for(std::chrono::milliseconds(period) - elapsed);
+        }
+
+        force_sensing_log.close();
+    }
+
+    void DensoController::ClosedLoopCommandServoJoint(std::vector<double> last_waypoint)
+    {
+        /* Repeat the last servo j command until the robot reaches tolerance or timeout */
+        double CLOSE_LOOP_JOINT_ANGLE_TOLERANCE = 0.0001; // rad
+        double CLOSE_LOOP_TIMEOUT = 0.1;                  // 100ms
+        int CLOSE_LOOP_MAX_ITERATION = 10;
+
+        std::vector<double> current_jnt_deg;
+        BCAP_HRESULT hr = read_driver.GetCurJnt(current_jnt_deg);
+        std::vector<double> current_jnt_rad = VDeg2Rad(current_jnt_deg);
+        if (FAILED(hr))
+        {
+            SPDLOG_ERROR("Closed loop servo j commands failed to get initial joint position");
+        }
+
+        // Print the initial joint error
+        std::vector<double> joint_error;
+        for (int i = 0; i < current_jnt_rad.size(); ++i)
+        {
+            joint_error.push_back(current_jnt_rad[i] - last_waypoint[i]);
+        }
+        char buffer[256] = {0};
+        std::sprintf(buffer, "Before closed-loop servo commands, joint error: [%.4f, %.4f, %.4f, %.4f, %.4f, %.4f]",
+                     joint_error[0], joint_error[1], joint_error[2], joint_error[3], joint_error[4], joint_error[5]);
+        SPDLOG_DEBUG(std::string(buffer));
+
+        int count = 0;
+        while (true)
+        {
+            // Check iteration count
+            if (count >= CLOSE_LOOP_MAX_ITERATION)
+            {
+                break;
+            }
+
+            // Check Joint Tolerance
+            hr = read_driver.GetCurJnt(current_jnt_deg);
+            if (FAILED(hr))
+            {
+                SPDLOG_ERROR("Closed loop servo j commands failed to get current joint position");
+                break;
+            }
+            current_jnt_rad = VDeg2Rad(current_jnt_deg);
+
+            bool all_within_tolerance = true;
+            for (int i = 0; i < current_jnt_rad.size(); ++i)
+            {
+                if (std::abs(current_jnt_rad[i] - last_waypoint[i]) > CLOSE_LOOP_JOINT_ANGLE_TOLERANCE)
+                {
+                    all_within_tolerance = false;
                     break;
                 }
             }
-        }
-
-        // High-precision sleep to maintain the desired frequency
-        auto end = std::chrono::steady_clock::now();
-        std::chrono::duration<double, std::milli> elapsed = end - start;
-        std::this_thread::sleep_for(std::chrono::milliseconds(period) - elapsed);
-    }
-
-    force_sensing_log.close();
-}
-
-void DensoController::ClosedLoopCommandServoJoint(std::vector<double> last_waypoint) {
-    /* Repeat the last servo j command until the robot reaches tolerance or timeout */
-    double CLOSE_LOOP_JOINT_ANGLE_TOLERANCE = 0.0001;  // rad
-    double CLOSE_LOOP_TIMEOUT = 0.1;  // 100ms
-    int CLOSE_LOOP_MAX_ITERATION = 10;
-
-    std::vector<double> current_jnt_deg;
-    BCAP_HRESULT hr = read_driver.GetCurJnt(current_jnt_deg);
-    std::vector<double> current_jnt_rad = VDeg2Rad(current_jnt_deg);
-    if (FAILED(hr)) {
-        SPDLOG_ERROR("Closed loop servo j commands failed to get initial joint position");
-    }
-    
-    // Print the initial joint error
-    std::vector<double> joint_error;
-    for (int i = 0; i < current_jnt_rad.size(); ++i) {
-        joint_error.push_back(current_jnt_rad[i] - last_waypoint[i]);
-    }
-    char buffer[256] = {0};
-    std::sprintf(buffer, "Before closed-loop servo commands, joint error: [%.4f, %.4f, %.4f, %.4f, %.4f, %.4f]",
-                joint_error[0], joint_error[1], joint_error[2], joint_error[3], joint_error[4], joint_error[5]);
-    SPDLOG_DEBUG(std::string(buffer));
-
-    int count = 0;
-    while (true) {
-        // Check iteration count
-        if (count >= CLOSE_LOOP_MAX_ITERATION)
-        {
-            break;
-        }
-
-        // Check Joint Tolerance
-        hr = read_driver.GetCurJnt(current_jnt_deg);
-        if (FAILED(hr)) {
-            SPDLOG_ERROR("Closed loop servo j commands failed to get current joint position");
-            break;
-        }
-        current_jnt_rad = VDeg2Rad(current_jnt_deg);
-
-        bool all_within_tolerance = true;
-        for (int i = 0; i < current_jnt_rad.size(); ++i) {
-            if (std::abs(current_jnt_rad[i] - last_waypoint[i]) > CLOSE_LOOP_JOINT_ANGLE_TOLERANCE) {
-                all_within_tolerance = false;
+            if (all_within_tolerance)
+            {
                 break;
             }
+
+            // Command the last waypoint again
+            BCAP_VARIANT vntPose = VNTFromRadVector(last_waypoint);
+            BCAP_VARIANT vntReturn;
+            write_driver.SlvMove(&vntPose, &vntReturn);
+
+            count++;
         }
-        if (all_within_tolerance) {
-            break;
+
+        // Print the joint remaining joint error
+        joint_error.clear();
+        for (int i = 0; i < current_jnt_rad.size(); ++i)
+        {
+            joint_error.push_back(current_jnt_rad[i] - last_waypoint[i]);
         }
-
-        // Command the last waypoint again
-        BCAP_VARIANT vntPose = VNTFromRadVector(last_waypoint);
-        BCAP_VARIANT vntReturn;
-        write_driver.SlvMove(&vntPose, &vntReturn);
-
-        count++;
+        std::memset(buffer, 0, sizeof(buffer));
+        std::sprintf(buffer, "After %d closed-loop servo commands, joint error: [%.4f, %.4f, %.4f, %.4f, %.4f, %.4f]",
+                     count, joint_error[0], joint_error[1], joint_error[2], joint_error[3], joint_error[4], joint_error[5]);
+        SPDLOG_DEBUG(std::string(buffer));
     }
 
-    // Print the joint remaining joint error
-    joint_error.clear();
-    for (int i = 0; i < current_jnt_rad.size(); ++i) {
-        joint_error.push_back(current_jnt_rad[i] - last_waypoint[i]);
+    void DensoController::HandleError(BCAP_HRESULT error_code, const char *error_description)
+    {
+        SPDLOG_ERROR("Error code: " + std::to_string(error_code));
+        SPDLOG_ERROR("Error description: " + std::string(error_description));
+        std::string controller_error = read_driver.GetErrorDescription(error_code);
+        SPDLOG_ERROR("Controller error message: " + controller_error);
+
+        Stop();
+        throw bCapException(
+            "Error code: " + std::to_string(error_code) + ". Error description: " + error_description + ". Controller error message: " + controller_error);
     }
-    std::memset(buffer, 0, sizeof(buffer));
-    std::sprintf(buffer, "After %d closed-loop servo commands, joint error: [%.4f, %.4f, %.4f, %.4f, %.4f, %.4f]",
-                count, joint_error[0], joint_error[1], joint_error[2], joint_error[3], joint_error[4], joint_error[5]);
-    SPDLOG_DEBUG(std::string(buffer));
-}
 
-void DensoController::HandleError(BCAP_HRESULT error_code, const char* error_description) {
-    SPDLOG_ERROR("Error code: " + std::to_string(error_code));
-    SPDLOG_ERROR("Error description: " + std::string(error_description));
-    std::string controller_error = read_driver.GetErrorDescription(error_code);
-    SPDLOG_ERROR("Controller error message: " + controller_error);
+    ////////////////////////////// Utilities //////////////////////////////
 
-    Stop();
-    throw bCapException(
-        "Error code: " + std::to_string(error_code)
-        + ". Error description: " + error_description
-        + ". Controller error message: " + controller_error
-    );
-}
-
-////////////////////////////// Utilities //////////////////////////////
-
-const char* DensoController::CommandFromVector(std::vector<double> q) {
-    std::vector<double> tmp;
-    tmp = VRad2Deg(q);
-    std::string commandstring;
-    commandstring = "J(" + std::to_string(tmp[0]) + ", " + std::to_string(tmp[1])
-                    + ", " + std::to_string(tmp[2]) + ", " + std::to_string(tmp[3])
-                    + ", " + std::to_string(tmp[4]) + ", " + std::to_string(tmp[5]) + ")";
-    return commandstring.c_str(); // convert string -> const shar*
-}
-
-std::vector<double> DensoController::VectorFromVNT(BCAP_VARIANT vnt0) {
-    std::vector<double> vect;
-    vect.resize(0);
-    for (int i = 0; i < 8; i++) {
-        vect.push_back(vnt0.Value.DoubleArray[i]);
+    const char *DensoController::CommandFromVector(std::vector<double> q)
+    {
+        std::vector<double> tmp;
+        tmp = VRad2Deg(q);
+        std::string commandstring;
+        commandstring = "J(" + std::to_string(tmp[0]) + ", " + std::to_string(tmp[1]) + ", " + std::to_string(tmp[2]) + ", " + std::to_string(tmp[3]) + ", " + std::to_string(tmp[4]) + ", " + std::to_string(tmp[5]) + ")";
+        return commandstring.c_str(); // convert string -> const shar*
     }
-    return vect;
-}
 
-BCAP_VARIANT DensoController::VNTFromVector(std::vector<double> vect0) {
-    assert(vect0.size() == 6 || vect0.size() == 8);
-    BCAP_VARIANT vnt;
-    vnt.Type = VT_R8 | VT_ARRAY;
-    vnt.Arrays = 8;
+    std::vector<double> DensoController::VectorFromVNT(BCAP_VARIANT vnt0)
+    {
+        std::vector<double> vect;
+        vect.resize(0);
+        for (int i = 0; i < 8; i++)
+        {
+            vect.push_back(vnt0.Value.DoubleArray[i]);
+        }
+        return vect;
+    }
 
-    for (int i = 0; i < int(vect0.size()); i++) {
-        vnt.Value.DoubleArray[i] = vect0[i];
-    }
-    return vnt;
-}
+    BCAP_VARIANT DensoController::VNTFromVector(std::vector<double> vect0)
+    {
+        assert(vect0.size() == 6 || vect0.size() == 8);
+        BCAP_VARIANT vnt;
+        vnt.Type = VT_R8 | VT_ARRAY;
+        vnt.Arrays = 8;
 
-std::vector<double> DensoController::RadVectorFromVNT(BCAP_VARIANT vnt0) {
-    std::vector<double> vect;
-    vect.resize(0);
-    for (int i = 0; i < 8; i++) {
-        vect.push_back(Deg2Rad(vnt0.Value.DoubleArray[i]));
+        for (int i = 0; i < int(vect0.size()); i++)
+        {
+            vnt.Value.DoubleArray[i] = vect0[i];
+        }
+        return vnt;
     }
-    return vect;
-}
 
-BCAP_VARIANT DensoController::VNTFromRadVector(std::vector<double> vect0) {
-    assert(vect0.size() == 6 || vect0.size() == 8);
-    BCAP_VARIANT vnt;
-    vnt.Type = VT_R8 | VT_ARRAY;
-    vnt.Arrays = 8;
+    std::vector<double> DensoController::RadVectorFromVNT(BCAP_VARIANT vnt0)
+    {
+        std::vector<double> vect;
+        vect.resize(0);
+        for (int i = 0; i < 8; i++)
+        {
+            vect.push_back(Deg2Rad(vnt0.Value.DoubleArray[i]));
+        }
+        return vect;
+    }
 
-    for (int i = 0; i < int(vect0.size()); i++) {
-        vnt.Value.DoubleArray[i] = Rad2Deg(vect0[i]);
-    }
-    return vnt;
-}
+    BCAP_VARIANT DensoController::VNTFromRadVector(std::vector<double> vect0)
+    {
+        assert(vect0.size() == 6 || vect0.size() == 8);
+        BCAP_VARIANT vnt;
+        vnt.Type = VT_R8 | VT_ARRAY;
+        vnt.Arrays = 8;
 
-std::vector<double> VRad2Deg(std::vector<double> vect0) {
-    std::vector<double> resvect;
-    resvect.resize(0);
-    for (int i = 0; i < int(vect0.size()); i++) {
-        resvect.push_back(Rad2Deg(vect0[i]));
+        for (int i = 0; i < int(vect0.size()); i++)
+        {
+            vnt.Value.DoubleArray[i] = Rad2Deg(vect0[i]);
+        }
+        return vnt;
     }
-    return resvect;
-}
 
-std::vector<double> VDeg2Rad(std::vector<double> vect0) {
-    std::vector<double> resvect;
-    resvect.resize(0);
-    for (int i = 0; i < int(vect0.size()); i++) {
-        resvect.push_back(Deg2Rad(vect0[i]));
+    std::vector<double> VRad2Deg(std::vector<double> vect0)
+    {
+        std::vector<double> resvect;
+        resvect.resize(0);
+        for (int i = 0; i < int(vect0.size()); i++)
+        {
+            resvect.push_back(Rad2Deg(vect0[i]));
+        }
+        return resvect;
     }
-    return resvect;
-}
 
-double Rad2Deg(double x) {
-    double res = x * 180.0 / PI;
-    if (res >= 0) {
-        return fmod(res, 360.0);
+    std::vector<double> VDeg2Rad(std::vector<double> vect0)
+    {
+        std::vector<double> resvect;
+        resvect.resize(0);
+        for (int i = 0; i < int(vect0.size()); i++)
+        {
+            resvect.push_back(Deg2Rad(vect0[i]));
+        }
+        return resvect;
     }
-    else{
-        return -1.0 * fmod(-1.0 * res, 360.0);
-    }
-}
 
-double Deg2Rad(double x) {
-    // double res;
-    if (x >= 0) {
-        return fmod(x, 360.0) * PI / 180.0;
+    double Rad2Deg(double x)
+    {
+        double res = x * 180.0 / PI;
+        if (res >= 0)
+        {
+            return fmod(res, 360.0);
+        }
+        else
+        {
+            return -1.0 * fmod(-1.0 * res, 360.0);
+        }
     }
-    else{
-        return -1.0 * fmod(-1.0 * x, 360.0) * PI / 180;
+
+    double Deg2Rad(double x)
+    {
+        // double res;
+        if (x >= 0)
+        {
+            return fmod(x, 360.0) * PI / 180.0;
+        }
+        else
+        {
+            return -1.0 * fmod(-1.0 * x, 360.0) * PI / 180;
+        }
     }
-}
 
 } // close namespace denso_controller

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -390,21 +390,6 @@ namespace denso_controller
         BCAP_HRESULT hr;
         for (size_t attempt = 0; attempt < 3; ++attempt)
         {
-            // BCAP_VARIANT vnt_mass;
-            // vnt_mass.Type = VT_I4;
-            // vnt_mass.Arrays = 1;
-            // vnt_mass.Value.LongValue = 1025;
-
-            // BCAP_VARIANT vnt_cog;
-            // vnt_cog.Type = VT_R4 | VT_ARRAY;
-            // vnt_cog.Arrays = 3;
-            // vnt_mass.Value.FloatArray[0] = 0.0;
-            // vnt_mass.Value.FloatArray[1] = 0.0;
-            // vnt_mass.Value.FloatArray[2] = 73.0;
-
-            // BCAP_VARIANT vnt_options[2] = {vnt_mass, vnt_cog};
-            BCAP_VARIANT vnt_result;
-
             hr = bCap_RobotExecute(iSockFD, lhRobot, "ForceSensor", mode, &lResult);
             if (SUCCEEDED(hr))
             {

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -566,9 +566,13 @@ namespace denso_controller
 
             if (FAILED(hr))
             {
+                // Stop the force sensing thread to prevent it from running indefinitely.
+                force_limit_exceeded = true;
+
                 std::string err_description = GetErrorDescription(hr);
                 SPDLOG_ERROR("Failed to execute b-CAP slave move. " + err_description);
                 std::string msg = "Index " + std::to_string(i) + " of " + std::to_string(traj.size()) + " ErrDescription: " + err_description;
+
                 throw SlaveMoveException(msg);
             }
 

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -110,11 +110,6 @@ void DensoReadDriver::bCapReleaseRobot() {
     }
 }
 
-/* Populates joint_positions with the current joint values.
-   joint_positions is mutated into a vector of 8 doubles.
-   The first 6 values are the joint angles in degrees, and the last 2 values
-   are the positions of the auxiliary axes, or 0 if they are not used.
- */
 BCAP_HRESULT DensoReadDriver::GetCurJnt(std::vector<double>& joint_positions) {
     double dJnt[8];
     BCAP_HRESULT hr;
@@ -137,11 +132,6 @@ BCAP_HRESULT DensoReadDriver::GetCurJnt(std::vector<double>& joint_positions) {
     return hr;
 }
 
-/* Populates force_values with the current force values.
-   force_values is mutated into a vector of 6 doubles.
-   The first 3 values are the force values, and the last 3 values are the
-   torque values.
- */
 BCAP_HRESULT DensoReadDriver::GetForceValue(std::vector<double>& force_values) {
     double dForce[6];
     BCAP_HRESULT hr;
@@ -164,8 +154,6 @@ BCAP_HRESULT DensoReadDriver::GetForceValue(std::vector<double>& force_values) {
     return hr;
 }
 
-/* Populates mounting_calib with the offset from the specified work coordinate.
- */
 std::tuple<BCAP_HRESULT, std::vector<double>>
 DensoReadDriver::GetMountingCalib(const char* work_coordinate) {
     double work_def[8]; // Should this be 6?

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -383,14 +383,14 @@ void DensoController::ExecuteServoTrajectory(
 
     // Start a thread to stream force sensor data, setting the
     _force_limit_exceeded = false;
-    std::thread force_sensing_thread(
-        &DensoController::_runForceSensingLoop,
-        this,
-        // TODO: Parameterize these values
-        1000.0,  // total force limit
-        1000.0,  // total torque limit
-        std::vector<double>{10.0, 10.0, 10.0, 10.0, 10.0, 10.0}  // tcp force/torque limit
-    );
+    // std::thread force_sensing_thread(
+    //     &DensoController::runForceSensingLoop,
+    //     this,
+    //     // TODO: Parameterize these values
+    //     1000.0,  // total force limit
+    //     1000.0,  // total torque limit
+    //     std::vector<double>{10.0, 10.0, 10.0, 10.0, 10.0, 10.0}  // tcp force/torque limit
+    // );
 
     // Enter slave mode: mode 2 J-Type
     hr = bCapSlvChangeMode("514");
@@ -447,7 +447,7 @@ void DensoController::ExecuteServoTrajectory(
 
     // Stop the force sensing thread
     _force_limit_exceeded = true;
-    force_sensing_thread.join();
+    // force_sensing_thread.join();
 }
 
 void DensoController::ClosedLoopCommandServoJoint(std::vector<double> last_waypoint) {
@@ -623,7 +623,7 @@ std::vector<double> VDeg2Rad(std::vector<double> vect0) {
     return resvect;
 }
 
-void DensoController::_runForceSensingLoop(
+void DensoController::runForceSensingLoop(
     double totalForceLimit,
     double totalTorqueLimit,
     std::vector<double> tcpForceTorqueLimit
@@ -637,6 +637,15 @@ void DensoController::_runForceSensingLoop(
             SPDLOG_ERROR("Failed to get force values.");
             throw bCapException("Force sensing failed.");
         }
+
+        SPDLOG_INFO(
+            "Force values: Fx: " + std::to_string(force_values[0]) +
+            ", Fy: " + std::to_string(force_values[1]) +
+            ", Fz: " + std::to_string(force_values[2]) +
+            ", Tx: " + std::to_string(force_values[3]) +
+            ", Ty: " + std::to_string(force_values[4]) +
+            ", Tz: " + std::to_string(force_values[5])
+        );
 
         // Check the total force does not exceed the limit
         double total_force = std::sqrt(

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <math.h>
 #include <time.h>
+#include <thread>
 
 #include <fstream>
 
@@ -410,7 +411,8 @@ namespace denso_controller
                 break;
             }
             SPDLOG_WARN("Failed to execute ForceSensor; attempt ", std::to_string(attempt));
-            sleep(0.001);
+            // Give some time to the controller in case it is busy
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
         if FAILED (hr)
         {
@@ -521,10 +523,11 @@ namespace denso_controller
             || total_torque_limit.has_value()
             || per_axis_force_torque_limits.has_value()
         ) {
+            // Wait some time for the arm and sensor to settle.
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
             // Reset the force sensor to prevent drift in the force readings.
             // Do it here, instead of in the force sensing thread, because this call
             // requires the arm mutex.
-            sleep(0.1);  // Wait some time for the arm and sensor to settle.
             hr = write_driver.ForceSensor("0");
         }
 

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -530,15 +530,15 @@ namespace denso_controller
         BCAP_VARIANT vntPose, vntReturn;
         for (size_t i = 0; i < traj.size(); i++)
         {
+            current_waypoint_index = i;
             // Stop if the force exceedance condition is true
-            if (force_limit_exceeded)
+            if (current_waypoint_index > 4 && force_limit_exceeded)
             {
                 SPDLOG_INFO("Force limit exceeded after " + std::to_string(current_waypoint_index) + " waypoints. Stopping trajectory execution.");
                 trajectory_execution_finished = false;
                 break;
             }
 
-            current_waypoint_index = i;
             const auto &joint_position = traj.trajectory[i];
             vntPose = VNTFromRadVector(joint_position);
             hr = write_driver.SlvMove(&vntPose, &vntReturn);

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -615,7 +615,7 @@ namespace denso_controller
             return;
         }
 
-        const int frequency = 100;           // Hz
+        const int frequency = 50;           // Hz
         const int period = 1000 / frequency; // period in milliseconds
 
         const int filter_size = 3;

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -502,6 +502,7 @@ namespace denso_controller
         // Reset the force sensor to prevent drift in the force readings.
         // Do it here, instead of in the force sensing thread, because this call
         // requires the arm mutex.
+        sleep(0.1);
         hr = write_driver.ForceSensor("0");
 
         // Start a thread to stream force sensor data, setting the
@@ -599,7 +600,7 @@ namespace denso_controller
         const int frequency = 100;           // Hz
         const int period = 1000 / frequency; // period in milliseconds
 
-        const int filter_size = 5;
+        const int filter_size = 3;
         const int force_value_data_size = 6; // x, y, z, rx, ry, rz
         filter::MeanFilter mean_filter(filter_size, force_value_data_size);
 

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -49,6 +49,30 @@ namespace denso_controller
         session_name = "read-only";
     }
 
+    void DensoReadDriver::Start()
+    {
+        bCapOpen();
+        SPDLOG_INFO("b-Cap port opened");
+        bCapServiceStart();
+        SPDLOG_INFO("b-Cap service started");
+        bCapControllerConnect();
+        SPDLOG_INFO("Connected to controller");
+        bCapGetRobot();
+        SPDLOG_INFO("Obtained robot handle");
+    }
+
+    void DensoReadDriver::Stop()
+    {
+        bCapReleaseRobot();
+        SPDLOG_INFO("Released robot handle");
+        bCapControllerDisconnect();
+        SPDLOG_INFO("Disconnected from controller");
+        bCapServiceStop();
+        SPDLOG_INFO("b-Cap service stopped");
+        bCapClose();
+        SPDLOG_INFO("b-Cap port closed");
+    }
+
     void DensoReadDriver::bCapOpen()
     {
         SPDLOG_INFO("Initialize and start b-CAP.");
@@ -385,26 +409,10 @@ namespace denso_controller
 
     void DensoController::Start()
     {
-        read_driver.bCapOpen();
-        SPDLOG_INFO("b-Cap port opened for read driver");
-        read_driver.bCapServiceStart();
-        SPDLOG_INFO("b-Cap service started for read driver");
-        read_driver.bCapControllerConnect();
-        SPDLOG_INFO("Connected to controller for read driver");
-        read_driver.bCapGetRobot();
-        SPDLOG_INFO("Obtained robot handle for read driver");
-
-        write_driver.bCapOpen();
-        SPDLOG_INFO("b-Cap port opened for write driver");
-        write_driver.bCapServiceStart();
-        SPDLOG_INFO("b-Cap service started for write driver");
-        write_driver.bCapControllerConnect();
-        SPDLOG_INFO("Connected to controller for write driver");
-        write_driver.bCapGetRobot();
-        SPDLOG_INFO("Obtained robot handle for write driver");
+        read_driver.Start();
+        write_driver.Start();
 
         BCAP_HRESULT hr;
-
         hr = ClearError();
         if FAILED (hr)
         {
@@ -437,15 +445,8 @@ namespace denso_controller
     {
         force_limit_exceeded = true;
 
-        read_driver.bCapReleaseRobot();
-        read_driver.bCapControllerDisconnect();
-        read_driver.bCapServiceStop();
-        read_driver.bCapClose();
-
-        write_driver.bCapReleaseRobot();
-        write_driver.bCapControllerDisconnect();
-        write_driver.bCapServiceStop();
-        write_driver.bCapClose();
+        read_driver.Stop();
+        write_driver.Stop();
     }
 
     BCAP_HRESULT DensoController::ClearError()

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -556,7 +556,7 @@ void DensoController::RunForceSensingLoop(
         return;
     }
 
-    std::ofstream force_sensing_log("force_sensing_log.txt");
+    std::ofstream force_sensing_log("force_sensing_log.txt", std::ios::app);
     if (!force_sensing_log.is_open()) {
         SPDLOG_ERROR("Failed to open force sensing log file.");
         throw bCapException("Force sensing logging failed.");

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -386,7 +386,25 @@ namespace denso_controller
         BCAP_HRESULT hr;
         for (size_t attempt = 0; attempt < 3; ++attempt)
         {
+            // BCAP_VARIANT vnt_mass;
+            // vnt_mass.Type = VT_I4;
+            // vnt_mass.Arrays = 1;
+            // vnt_mass.Value.LongValue = 1025;
+
+            // BCAP_VARIANT vnt_cog;
+            // vnt_cog.Type = VT_R4 | VT_ARRAY;
+            // vnt_cog.Arrays = 3;
+            // vnt_mass.Value.FloatArray[0] = 0.0;
+            // vnt_mass.Value.FloatArray[1] = 0.0;
+            // vnt_mass.Value.FloatArray[2] = 73.0;
+
+            // BCAP_VARIANT vnt_options[2] = {vnt_mass, vnt_cog};
+            BCAP_VARIANT vnt_result;
+
+            std::cout << "ForceSensor" << std::endl;
             hr = bCap_RobotExecute(iSockFD, lhRobot, "ForceSensor", mode, &lResult);
+            // std::cout << "PayLoad" << std::endl;
+            // hr = bCap_RobotExecute2(iSockFD, lhRobot, "ForceSensorPayLoad", &vnt_mass, &vnt_result);
             if (SUCCEEDED(hr))
             {
                 break;
@@ -593,7 +611,7 @@ namespace denso_controller
         // Exit early if no force limits are specified
         if (!total_force_limit.has_value() && !total_torque_limit.has_value() && !per_axis_force_torque_limits.has_value())
         {
-            std::cout << "Exit force sensing loop early" << std::endl;
+            std::cout << "Skip force sensing loop" << std::endl;
             return;
         }
 

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -616,7 +616,7 @@ namespace denso_controller
         // Exit early if no force limits are specified
         if (!total_force_limit.has_value() && !total_torque_limit.has_value() && !per_axis_force_torque_limits.has_value())
         {
-            std::cout << "Skip force sensing loop" << std::endl;
+            SPDLOG_INFO("Skip force sensing loop");
             return;
         }
 
@@ -670,8 +670,8 @@ namespace denso_controller
                 std::pow(force_values[0], 2) + std::pow(force_values[1], 2) + std::pow(force_values[2], 2));
             if (total_force_limit.has_value() && total_force > *total_force_limit)
             {
-                std::cout << "Force limit exceeded. Total force: " << std::to_string(total_force) << std::endl;
-                std::cout << "Force limit: " << *total_force_limit << std::endl;
+                SPDLOG_INFO("Force limit exceeded. Total force: " + std::to_string(total_force)
+                            + ". Force limit: " + std::to_string(*total_force_limit));
                 force_limit_exceeded = true;
                 break;
             }
@@ -681,7 +681,8 @@ namespace denso_controller
                 std::pow(force_values[3], 2) + std::pow(force_values[4], 2) + std::pow(force_values[5], 2));
             if (total_torque_limit.has_value() && total_torque > *total_torque_limit)
             {
-                std::cout << "Torque limit exceeded. Total torque: " << std::to_string(total_torque) << std::endl;
+                SPDLOG_INFO("Torque limit exceeded. Total torque: " + std::to_string(total_torque)
+                            + ". Torque limit: " + std::to_string(*total_torque_limit));
                 force_limit_exceeded = true;
                 break;
             }
@@ -693,7 +694,7 @@ namespace denso_controller
                 {
                     if (std::abs(force_values[i]) > (*per_axis_force_torque_limits)[i])
                     {
-                        std::cout << "TCP force/torque limit exceeded. Force/Torque: " << std::to_string(force_values[i]) << std::endl;
+                        SPDLOG_INFO("TCP force/torque limit exceeded. Force/Torque: " + std::to_string(force_values[i]));
                         force_limit_exceeded = true;
                         break;
                     }

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -443,11 +443,12 @@ DensoController::GetJointPositions() {
 }
 
 
-void DensoController::ExecuteServoTrajectory(
+bool DensoController::ExecuteServoTrajectory(
     RobotTrajectory& traj
     // TODO: add force threshold parameters
 )
 {
+    bool trajectory_execution_finished = true;
     BCAP_HRESULT hr;
     long lResult;
 
@@ -466,7 +467,7 @@ void DensoController::ExecuteServoTrajectory(
         // TODO: Parameterize these values
         1000.0,  // total force limit
         1000.0,  // total torque limit
-        std::vector<double>{1000.0, 1000.0, 1000.0, 1000.0, 1000.0, 1000.0}  // tcp force/torque limit
+        std::vector<double>{1000.0, 1000.0, 20.0, 1000.0, 1000.0, 1000.0}  // tcp force/torque limit
     );
 
     // Enter slave mode
@@ -484,6 +485,7 @@ void DensoController::ExecuteServoTrajectory(
         // Stop if the force exceedance condition is true
         if (force_limit_exceeded) {
             SPDLOG_INFO("Force limit exceeded. Stopping trajectory execution.");
+            trajectory_execution_finished = false;
             break;
         }
 
@@ -526,6 +528,7 @@ void DensoController::ExecuteServoTrajectory(
     }
     SPDLOG_INFO("Slave mode OFF");
 
+    return trajectory_execution_finished;
 }
 
 void DensoController::RunForceSensingLoop(

--- a/medra_pybind/src/b-Cap.c
+++ b/medra_pybind/src/b-Cap.c
@@ -2440,7 +2440,7 @@ BCAP_HRESULT Packet_GetResult(BCAP_PACKET *pRecPacket, void *pResult){
                     //memcpy(pResult, (char*)pArgValue->data+BCAP_SIZE_ARGSTRLEN, pArgValue->lArrays);
 
                     for (i = 0; i < pArgValue->lArrays; i++) {
-                        lSize = copyFromBSTR(pDstAscii, pSrcBstr);
+                        lSize = copyFromBSTRAsUTF8(pDstAscii, pSrcBstr);
                         pDstAscii += lSize;
                         pSrcBstr += BCAP_SIZE_ARGSTRLEN + ((lSize -1) * 2); /* lSize include Terminator,so (lSize -1) * 2) */
                     }
@@ -2697,22 +2697,6 @@ static uint32_t copyFromBSTR(void *pDstAsciiPtr, void *pSrcBstrPtr){
         lLen2 += sizeof(u_short);
     }
     return (lLen2);
-}
-
-// Function to convert UTF-16LE to UTF-8
-char* utf16le_to_utf8(const uint16_t* utf16_str, size_t utf16_len) {
-    wchar_t* wide_str = malloc((utf16_len + 1) * sizeof(wchar_t));
-    for (size_t i = 0; i < utf16_len; i++) {
-        wide_str[i] = utf16_str[i];
-    }
-    wide_str[utf16_len] = L'\0';
-
-    size_t utf8_len = wcstombs(NULL, wide_str, 0);
-    char* utf8_str = malloc(utf8_len + 1);
-    wcstombs(utf8_str, wide_str, utf8_len + 1);
-
-    free(wide_str);
-    return utf8_str;
 }
 
 /**	Convert From BSTR into AsciiZ

--- a/medra_pybind/src/b-Cap.c
+++ b/medra_pybind/src/b-Cap.c
@@ -2440,7 +2440,7 @@ BCAP_HRESULT Packet_GetResult(BCAP_PACKET *pRecPacket, void *pResult){
                     //memcpy(pResult, (char*)pArgValue->data+BCAP_SIZE_ARGSTRLEN, pArgValue->lArrays);
 
                     for (i = 0; i < pArgValue->lArrays; i++) {
-                        lSize = copyFromBSTRAsUTF8(pDstAscii, pSrcBstr);
+                        lSize = copyFromBSTR(pDstAscii, pSrcBstr);
                         pDstAscii += lSize;
                         pSrcBstr += BCAP_SIZE_ARGSTRLEN + ((lSize -1) * 2); /* lSize include Terminator,so (lSize -1) * 2) */
                     }

--- a/medra_pybind/src/bindings.cpp
+++ b/medra_pybind/src/bindings.cpp
@@ -68,51 +68,22 @@ PYBIND11_MODULE(_medra_bcap, m) {
   py::class_<DensoController>(m, "DensoController")
     .def(py::init<>())
 
-    // Low level commands
-    .def("bCapOpen", &DensoController::bCapOpen, py::call_guard<py::gil_scoped_release>())
-    .def("bCapClose", &DensoController::bCapClose, py::call_guard<py::gil_scoped_release>())
-    .def("bCapServiceStart", &DensoController::bCapServiceStart, py::call_guard<py::gil_scoped_release>())
-    .def("bCapServiceStop", &DensoController::bCapServiceStop, py::call_guard<py::gil_scoped_release>())
-    .def("bCapControllerConnect", &DensoController::bCapControllerConnect, py::call_guard<py::gil_scoped_release>())
-    .def("bCapControllerDisconnect", &DensoController::bCapControllerDisconnect, py::call_guard<py::gil_scoped_release>())
-    .def("bCapGetRobot", &DensoController::bCapGetRobot, py::call_guard<py::gil_scoped_release>())
-    .def("bCapReleaseRobot", &DensoController::bCapReleaseRobot, py::call_guard<py::gil_scoped_release>())
-    .def("bCapClearError", &DensoController::bCapClearError, py::call_guard<py::gil_scoped_release>())
-    .def("bCapRobotExecute", &DensoController::bCapRobotExecute, py::call_guard<py::gil_scoped_release>())
-    .def("bCapRobotMove", &DensoController::bCapRobotMove, py::call_guard<py::gil_scoped_release>())
-    .def("bCapMotor", &DensoController::bCapMotor, py::call_guard<py::gil_scoped_release>())
-    .def("bCapSlvChangeMode", &DensoController::bCapSlvChangeMode, py::call_guard<py::gil_scoped_release>())
-    .def("bCapSlvMove", &DensoController::bCapSlvMove, py::call_guard<py::gil_scoped_release>())
-    .def("SetExtSpeed", &DensoController::SetExtSpeed, py::call_guard<py::gil_scoped_release>())
-    .def("ManualReset", &DensoController::ManualReset, py::call_guard<py::gil_scoped_release>())
-    .def("SetTcpLoad", &DensoController::SetTcpLoad, py::call_guard<py::gil_scoped_release>())
-    .def("GetMountingCalib", &DensoController::GetMountingCalib, py::call_guard<py::gil_scoped_release>())
+    // High level commands
+    .def("Start", [](DensoController &dc) {
+      setup_pybind11_logging();
+      return dc.Start();
+    }, py::call_guard<py::gil_scoped_release>())
+    .def("Stop", &DensoController::Stop, py::call_guard<py::gil_scoped_release>())
+
+    // Error handling functions
+    .def("ClearError", &DensoController::ClearError, py::call_guard<py::gil_scoped_release>())
     .def("GetErrorDescription", &DensoController::GetErrorDescription, py::call_guard<py::gil_scoped_release>())
 
-    // High level commands
-    .def("bCapEnterProcess", [](DensoController &dc) {
-      setup_pybind11_logging();
-      return dc.bCapEnterProcess();
-    }, py::call_guard<py::gil_scoped_release>())
-
-    .def("bCapExitProcess", &DensoController::bCapExitProcess, py::call_guard<py::gil_scoped_release>())
-    .def("CommandServoJoint", &DensoController::CommandServoJoint, py::call_guard<py::gil_scoped_release>())
+    .def("GetJointPositions", &DensoController::GetJointPositions, py::call_guard<py::gil_scoped_release>())
     .def("ExecuteServoTrajectory", &DensoController::ExecuteServoTrajectory, py::call_guard<py::gil_scoped_release>())
+    .def("SetTcpLoad", &DensoController::SetTcpLoad, py::call_guard<py::gil_scoped_release>())
+    .def("GetMountingCalib", &DensoController::GetMountingCalib, py::call_guard<py::gil_scoped_release>())
 
-    // Utilities
-    .def("CommandFromVector", &DensoController::CommandFromVector, py::call_guard<py::gil_scoped_release>())
-    .def("GetCurJnt", &DensoController::GetCurJnt, py::call_guard<py::gil_scoped_release>())
-    .def("VectorFromVNT", &DensoController::VectorFromVNT, py::call_guard<py::gil_scoped_release>())
-    .def("RadVectorFromVNT", &DensoController::RadVectorFromVNT, py::call_guard<py::gil_scoped_release>())
-    .def("VNTFromVector", &DensoController::VNTFromVector, py::call_guard<py::gil_scoped_release>())
-    .def("VNTFromRadVector", &DensoController::VNTFromRadVector, py::call_guard<py::gil_scoped_release>())
-
-    // Class members
-    .def_readonly("server_ip_address", &DensoController::server_ip_address)
-    .def_readonly("server_port_num", &DensoController::server_port_num)
-    .def_readonly("iSockFD", &DensoController::iSockFD)
-    .def_readonly("lhController", &DensoController::lhController)
-    .def_readonly("lhRobot", &DensoController::lhRobot)
     .def_readonly("current_waypoint_index", &DensoController::current_waypoint_index);
 
 

--- a/medra_pybind/src/bindings.cpp
+++ b/medra_pybind/src/bindings.cpp
@@ -77,17 +77,20 @@ PYBIND11_MODULE(_medra_bcap, m) {
 
     // Error handling functions
     .def("ClearError", &DensoController::ClearError, py::call_guard<py::gil_scoped_release>())
-    .def("GetErrorDescription", &DensoController::GetErrorDescription, py::call_guard<py::gil_scoped_release>())
+    .def("GetErrorDescription", &DensoController::GetErrorDescription, py::call_guard<py::gil_scoped_release>(),
+          py::arg("error_code")
+    )
 
     .def("GetJointPositions", &DensoController::GetJointPositions, py::call_guard<py::gil_scoped_release>())
-    .def("ExecuteServoTrajectory", &DensoController::ExecuteServoTrajectory, py::call_guard<py::gil_scoped_release>())
-    .def("SetTcpLoad", &DensoController::SetTcpLoad, py::call_guard<py::gil_scoped_release>())
-    .def("GetMountingCalib", &DensoController::GetMountingCalib, py::call_guard<py::gil_scoped_release>())
+    .def("ExecuteServoTrajectory", &DensoController::ExecuteServoTrajectory, py::call_guard<py::gil_scoped_release>(),
+          py::arg("traj"), py::arg("total_force_limit"), py::arg("total_torque_limit"), py::arg("per_axis_force_torque_limits")
+    )
+    .def("SetTcpLoad", &DensoController::SetTcpLoad, py::call_guard<py::gil_scoped_release>(),
+          py::arg("tool_value")
+    )
+    .def("GetMountingCalib", &DensoController::GetMountingCalib, py::call_guard<py::gil_scoped_release>(),
+          py::arg("work_coordinate")
+    )
 
     .def_readonly("current_waypoint_index", &DensoController::current_waypoint_index);
-
-
-  m.def("VRad2Deg", &VRad2Deg);
-  m.def("Rad2Deg", &Rad2Deg);
-  m.def("Deg2Rad", &Deg2Rad);
 }

--- a/medra_pybind/src/filter.cpp
+++ b/medra_pybind/src/filter.cpp
@@ -30,9 +30,9 @@ void MeanFilter::AddValue(std::vector<double> new_value) {
 }
 
 std::vector<double> MeanFilter::GetMean() {
-    std::vector<double> mean_vector;
+    std::vector<double> mean_vector = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
     for (size_t i = 0; i < measurement_size; i++) {
-        mean_vector.push_back(sum_vector[i] / window_count);
+        mean_vector[i] = sum_vector[i] / window_count;
     }
     return mean_vector;
 }

--- a/medra_pybind/src/filter.cpp
+++ b/medra_pybind/src/filter.cpp
@@ -1,0 +1,40 @@
+#include "filter.hpp"
+
+namespace filter {
+
+MeanFilter::MeanFilter(const size_t window_size, const size_t measurement_size) :
+    window_size(window_size),
+    measurement_size(measurement_size),
+    window_count(0),
+    sum_vector(std::vector<double>(measurement_size, 0.0))
+{}
+
+void MeanFilter::AddValue(std::vector<double> new_value) {
+    if (new_value.size() != measurement_size) {
+        throw std::invalid_argument("Input vector size does not match measurement size.");
+    }
+
+    std::vector<double> oldest_value;
+    if (window.size() < window_size) {
+        oldest_value = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        window_count++;
+    } else {
+        oldest_value = window.front();
+        window.pop();
+    }
+
+    for (size_t i = 0; i < measurement_size; i++) {
+        sum_vector[i] += new_value[i] - oldest_value[i];
+    }
+    window.push(new_value);
+}
+
+std::vector<double> MeanFilter::GetMean() {
+    std::vector<double> mean_vector;
+    for (size_t i = 0; i < measurement_size; i++) {
+        mean_vector.push_back(sum_vector[i] / window_count);
+    }
+    return mean_vector;
+}
+
+}  // end namespace filter

--- a/medra_pybind/tests/test_execute_servo_trajectory.cpp
+++ b/medra_pybind/tests/test_execute_servo_trajectory.cpp
@@ -75,8 +75,14 @@ int main(){
 
     // Execute the trajectory
     for (size_t iters = 0; iters < 100000; ++iters) {
-        controller.ExecuteServoTrajectory(forward_trajectory);
-        controller.ExecuteServoTrajectory(reverse_trajectory);
+        if (!controller.ExecuteServoTrajectory(forward_trajectory)) {
+            std::cout << "Stopped early" << std::endl;
+            break;
+        }
+        if (!controller.ExecuteServoTrajectory(reverse_trajectory)) {
+            std::cout << "Stopped early" << std::endl;
+            break;
+        }
     }
 
     controller.Stop();

--- a/medra_pybind/tests/test_execute_servo_trajectory.cpp
+++ b/medra_pybind/tests/test_execute_servo_trajectory.cpp
@@ -71,7 +71,7 @@ int main(){
             currentPose[2],
             currentPose[3],
             currentPose[4],
-            currentPose[5] + 0.0001,
+            currentPose[5] + 0.001,
         };
         trajectory_poses.push_back(newPose);
         currentPose = newPose;
@@ -93,6 +93,9 @@ int main(){
 
     // Execute the trajectory
     controller.ExecuteServoTrajectory(trajectory);
+
+    second_controller.force_limit_exceeded = true;
+    force_sensing_thread.join();
 
     controller.bCapExitProcess();
     second_controller.bCapExitProcess();

--- a/medra_pybind/tests/test_execute_servo_trajectory.cpp
+++ b/medra_pybind/tests/test_execute_servo_trajectory.cpp
@@ -52,7 +52,7 @@ int main(){
 
     std::vector<std::vector<double>> forward_trajectory_poses = {currentPose};
     std::vector<std::vector<double>> reverse_trajectory_poses = {};
-    for (size_t i = 0; i < 100; i++) {
+    for (size_t i = 0; i < 1000; i++) {
         std::vector<double> newPose = {
             currentPose[0],
             currentPose[1],

--- a/medra_pybind/tests/test_execute_servo_trajectory.cpp
+++ b/medra_pybind/tests/test_execute_servo_trajectory.cpp
@@ -25,7 +25,7 @@ int main(){
     double dJnt[8];
     BCAP_VARIANT vntPose, vntReturn;
 
-    denso_controller::DensoController controller = denso_controller::DensoController();
+    denso_controller::DensoController controller;
     controller.bCapEnterProcess();
     BCAP_HRESULT speed_hr = controller.SetExtSpeed("100");
 

--- a/medra_pybind/tests/test_execute_servo_trajectory.cpp
+++ b/medra_pybind/tests/test_execute_servo_trajectory.cpp
@@ -5,7 +5,6 @@
 #include <iostream>
 #include <unistd.h>
 #include <vector>
-#include <thread>
 
 #define SERVER_IP_ADDRESS    "192.168.0.1"
 #define SERVER_PORT_NUM      5007

--- a/medra_pybind/tests/test_execute_servo_trajectory.cpp
+++ b/medra_pybind/tests/test_execute_servo_trajectory.cpp
@@ -59,7 +59,7 @@ int main(){
             currentPose[2],
             currentPose[3],
             currentPose[4],
-            currentPose[5] + 0.001,
+            currentPose[5],
         };
         forward_trajectory_poses.push_back(newPose);
         reverse_trajectory_poses.insert(reverse_trajectory_poses.begin(), currentPose);
@@ -75,21 +75,22 @@ int main(){
 
     // Execute the trajectory
     for (size_t iters = 0; iters < 100000; ++iters) {
-        std::optional<std::vector<double>> force_vector = std::vector<double>{10000.0, 10000.0, 10.0, 10000.0, 10000.0, 10000.0};
+        // std::optional<std::vector<double>> force_vector = std::vector<double>{10000.0, 10000.0, 10.0, 10000.0, 10000.0, 10000.0};
+        auto total_force_limit = 10.0;
         if (!controller.ExecuteServoTrajectory(
             forward_trajectory,
+            total_force_limit,
             std::nullopt,
-            std::nullopt,
-            force_vector
+            std::nullopt
         )) {
             std::cout << "Stopped early" << std::endl;
             break;
         }
         if (!controller.ExecuteServoTrajectory(
             reverse_trajectory,
+            total_force_limit,
             std::nullopt,
-            std::nullopt,
-            force_vector
+            std::nullopt
         )) {
             std::cout << "Stopped early" << std::endl;
             break;

--- a/medra_pybind/tests/test_execute_servo_trajectory.cpp
+++ b/medra_pybind/tests/test_execute_servo_trajectory.cpp
@@ -75,11 +75,22 @@ int main(){
 
     // Execute the trajectory
     for (size_t iters = 0; iters < 100000; ++iters) {
-        if (!controller.ExecuteServoTrajectory(forward_trajectory)) {
+        std::optional<std::vector<double>> force_vector = std::vector<double>{10000.0, 10000.0, 10.0, 10000.0, 10000.0, 10000.0};
+        if (!controller.ExecuteServoTrajectory(
+            forward_trajectory,
+            std::nullopt,
+            std::nullopt,
+            force_vector
+        )) {
             std::cout << "Stopped early" << std::endl;
             break;
         }
-        if (!controller.ExecuteServoTrajectory(reverse_trajectory)) {
+        if (!controller.ExecuteServoTrajectory(
+            reverse_trajectory,
+            std::nullopt,
+            std::nullopt,
+            force_vector
+        )) {
             std::cout << "Stopped early" << std::endl;
             break;
         }

--- a/medra_pybind/tests/test_execute_servo_trajectory.cpp
+++ b/medra_pybind/tests/test_execute_servo_trajectory.cpp
@@ -52,14 +52,14 @@ int main(){
 
     std::vector<std::vector<double>> forward_trajectory_poses = {currentPose};
     std::vector<std::vector<double>> reverse_trajectory_poses = {};
-    for (size_t i = 0; i < 1000; i++) {
+    for (size_t i = 0; i < 100; i++) {
         std::vector<double> newPose = {
             currentPose[0],
             currentPose[1],
             currentPose[2],
             currentPose[3],
             currentPose[4],
-            currentPose[5],
+            currentPose[5] + 0.001,
         };
         forward_trajectory_poses.push_back(newPose);
         reverse_trajectory_poses.insert(reverse_trajectory_poses.begin(), currentPose);


### PR DESCRIPTION
- Adds 100Hz force sensing in a separate thread to ExecuteServoTrajectory(), stopping execution early if limits are hit.
- Force sensing cannot be done in the same thread because a b-CAP client in slave mode cannot call functions other than `slvMove`, `slvGetMode`, and `slvChangeMode`. From RC9 manual:

<img width="562" alt="image" src="https://github.com/user-attachments/assets/bf53054f-4fca-4b90-902a-51419ed0fc4a">

- Refactor `DensoController` to create two connections to the controller box.
  - One is for reading only, and is maintained by a `DensoReadDriver`. This connection is used to call `CurJnt` and `forceValue`, among other functions.
  - The other is for writing, and is used for `slvMove` among other functions.
- **Bumps C++ version from 11 to 20 to be able to use `std::optional`, introduced in 17**
- Uses mean filtering with a window size of 3 to smooth the force data. See [Notion docs](https://www.notion.so/medra-ai/Force-data-filtering-43507074e2844134b67a157a37555fe1?pvs=4) for motivation 
