### PR TITLE
fix: Return trajectory execution information

### DIFF
--- a/medra_pybind/CMakeLists.txt
+++ b/medra_pybind/CMakeLists.txt
@@ -7,6 +7,16 @@ message ("CMake Compiler: " ${CMAKE_CXX_COMPILER})
 message ("CMake Compiler ID: " ${CMAKE_CXX_COMPILER_ID})
 message ("CMake Compiler version: " ${CMAKE_CXX_COMPILER_VERSION})
 
+# Compiler flags
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  message(FATAL_ERROR "MSVC compiler is not supported.")
+endif()
+
+message("Using GNU or Clang compiler")
+add_compile_options(-Wswitch -Wswitch-enum)  # Checks that all switch cases are covered
+add_compile_options(-Wall)  # Enable all warnings
+add_compile_options(-Wextra)  # Enable extra warnings
+
 # Set the names and sources of the module
 set(MODULE_NAME medra_bcap)
 set(PYBIND11_SOURCES 

--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -29,9 +29,13 @@
 #define SERVO_MODE_ON "514"  // Mode 2 J-type
 #define SERVO_MODE_OFF "0"   // Servo mode off
 
+// List of errors which we can retry SlvMove on.
 const std::vector<BCAP_HRESULT> VALID_SLVMOVE_ERRORS({
     BCAP_E_COMMAND_BUFFER_EMPTY,
-    BCAP_E_COMMAND_POSITION_GEN_STOPPED
+    BCAP_E_COMMAND_POSITION_GEN_STOPPED,
+    // Another common error during buffer underflow is BCAP_E_SLVMODE_OFF.
+    // We don't catch this one since it could be caused by a host of errors
+    // which may not all be valid.
 });
 
 namespace denso_controller {

--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -29,6 +29,11 @@
 #define SERVO_MODE_ON "514"  // Mode 2 J-type
 #define SERVO_MODE_OFF "0"   // Servo mode off
 
+const std::vector<BCAP_HRESULT> VALID_SLVMOVE_ERRORS({
+    BCAP_E_COMMAND_BUFFER_EMPTY,
+    BCAP_E_COMMAND_POSITION_GEN_STOPPED
+});
+
 namespace denso_controller {
 
 class bCapException : public std::exception {

--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -190,6 +190,18 @@ public:
     // Returns a tuple containing the error code and the joint positions in
     // radians.
     std::tuple<BCAP_HRESULT, std::vector<double>> GetJointPositions();
+
+    enum class ExecuteServoTrajectoryError {
+        SUCCESS,
+        ENTER_SLAVE_MODE_FAILED,
+        SLAVE_MOVE_FAILED,
+        EXIT_SLAVE_MODE_FAILED
+    };
+    enum class ExecuteServoTrajectoryResult {
+        COMPLETE,
+        FORCE_LIMIT_EXCEEDED,
+        ERROR
+    };
     // Executes a trajectory of joint angles in radians.
     // total_force_limit, total_torque_limit, and per_axis_force_torque_limits
     // describe stopping criteria for trajectory execution based on force
@@ -199,14 +211,15 @@ public:
     //   2. If the total torque exceeds total_torque_limit Nm, or
     //   3. If the force or torque on any axis exceeds the corresponding limit
     //     in per_axis_force_torque_limits.
-    // The return value is true if the trajectory fully executed, and false if
-    // it was stopped early.
-    bool ExecuteServoTrajectory(
+    // Returns an error code and a result for whether execution finished.
+    std::tuple<ExecuteServoTrajectoryError, ExecuteServoTrajectoryResult>
+    ExecuteServoTrajectory(
         const RobotTrajectory& traj,
         const std::optional<double> total_force_limit = std::nullopt,
         const std::optional<double> total_torque_limit = std::nullopt,
         const std::optional<std::vector<double>> per_axis_force_torque_limits = std::nullopt
     );
+
     BCAP_HRESULT SetTcpLoad(const int32_t tool_value);
     std::tuple<BCAP_HRESULT, std::vector<double>> GetMountingCalib(const char* work_coordinate);
 
@@ -235,9 +248,30 @@ private:
         const std::optional<std::vector<double>> per_axis_force_torque_limits
     );
 
+    enum class EnterSlaveModeResult {
+        SUCCESS, ENTER_SLAVE_MODE_FAILED
+    };
+    EnterSlaveModeResult EnterSlaveMode();
+
+    enum class ExitSlaveModeResult {
+        SUCCESS, EXIT_SLAVE_MODE_FAILED
+    };
+    ExitSlaveModeResult ExitSlaveMode();
+
+    enum class CommandServoJointResult {
+        SUCCESS, SLAVE_MOVE_FAILED
+    };
+    // Commands the robot to move to a joint position, in radians, in slave mode.
+    CommandServoJointResult CommandServoJoint(const std::vector<double>& waypoint);
+
+    enum class ClosedLoopCommandServoJointResult {
+        SUCCESS,
+        GET_CUR_JNT_FAILED,
+        SLAVE_MOVE_FAILED
+    };
     // Repeatedly commands a joint position in slave mode until the robot's
     // current joint position is within a small tolerance of it.
-    void ClosedLoopCommandServoJoint(const std::vector<double>& waypoint);
+    ClosedLoopCommandServoJointResult ClosedLoopCommandServoJoint(const std::vector<double>& waypoint);
 
     // Error handling
     void HandleError(BCAP_HRESULT error_code, const char* error_description);

--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -29,15 +29,6 @@
 #define SERVO_MODE_ON "514"  // Mode 2 J-type
 #define SERVO_MODE_OFF "0"   // Servo mode off
 
-// List of errors which we can retry SlvMove on.
-const std::vector<BCAP_HRESULT> VALID_SLVMOVE_ERRORS({
-    BCAP_E_COMMAND_BUFFER_EMPTY,
-    BCAP_E_COMMAND_POSITION_GEN_STOPPED,
-    // Another common error during buffer underflow is BCAP_E_SLVMODE_OFF.
-    // We don't catch this one since it could be caused by a host of errors
-    // which may not all be valid.
-});
-
 namespace denso_controller {
 
 class bCapException : public std::exception {

--- a/medra_pybind/include/DensoController.hpp
+++ b/medra_pybind/include/DensoController.hpp
@@ -195,7 +195,8 @@ public:
         SUCCESS,
         ENTER_SLAVE_MODE_FAILED,
         SLAVE_MOVE_FAILED,
-        EXIT_SLAVE_MODE_FAILED
+        EXIT_SLAVE_MODE_FAILED,
+        FORCE_SENSOR_RESET_FAILED
     };
     enum class ExecuteServoTrajectoryResult {
         COMPLETE,

--- a/medra_pybind/include/b-Cap.h
+++ b/medra_pybind/include/b-Cap.h
@@ -141,6 +141,12 @@ typedef int32_t BCAP_HRESULT;
  */
 #define BCAP_E_COMMAND_POSITION_GEN_STOPPED ((BCAP_HRESULT)0x84201486L)
 
+/**
+ * @def BCAP_E_SLVMODE_OFF
+ * @brief Slave move command was executed while slave mode was off.
+ */
+#define BCAP_E_SLVMODE_OFF ((BCAP_HRESULT)0x83500121L)
+
 /* b-CAP Type id */
 #define VT_EMPTY                0           /* (0Byte) */
 #define VT_NULL                 1           /* (0Byte) */

--- a/medra_pybind/include/b-Cap.h
+++ b/medra_pybind/include/b-Cap.h
@@ -129,6 +129,17 @@ typedef int32_t BCAP_HRESULT;
  */
 #define BCAP_E_INVALIDARG ((BCAP_HRESULT)0x80070057L)
 
+/**
+ * @def BCAP_E_COMMAND_BUFFER_EMPTY
+ * @brief Slave mode command buffer is empty.
+ */
+#define BCAP_E_COMMAND_BUFFER_EMPTY ((BCAP_HRESULT)0x84201482L)
+
+/**
+ * @def BCAP_E_COMMAND_POSITION_GEN_STOPPED
+ * @brief Command position generation is stopped.
+ */
+#define BCAP_E_COMMAND_POSITION_GEN_STOPPED ((BCAP_HRESULT)0x84201486L)
 
 /* b-CAP Type id */
 #define VT_EMPTY                0           /* (0Byte) */

--- a/medra_pybind/include/logging.hpp
+++ b/medra_pybind/include/logging.hpp
@@ -39,6 +39,7 @@ LevelFilter map_level(spdlog::level::level_enum level) {
       return LevelFilter::Error;
     case spdlog::level::critical:
       return LevelFilter::Critical;
+    case spdlog::level::n_levels:
     case spdlog::level::off:
     default:
       return LevelFilter::Off;

--- a/medra_pybind/pyproject.toml
+++ b/medra_pybind/pyproject.toml
@@ -10,4 +10,4 @@ build-dir = "build"
 
 [project]
 name = "medra_bcap"
-version = "0.1.8"
+version = "0.1.9"

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -870,6 +870,8 @@ namespace denso_controller
             }
             SPDLOG_WARN("Failed to command servo joint, attempt " + std::to_string(attempt));
             ClearError();
+            write_driver.ManualReset();
+            write_driver.Motor(true);
             EnterSlaveMode();  // If this call fails, it will be caught in the next iteration
         }
 

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -867,7 +867,12 @@ namespace denso_controller
         {
             return CommandServoJointResult::SUCCESS;
         }
-        SPDLOG_ERROR("Failed to command servo joint.");
+        SPDLOG_ERROR("Failed to command servo joint. Resetting robot.");
+
+        write_driver.ClearError();
+        write_driver.ManualReset();
+        SPDLOG_INFO("Cleared errors after failed servo command.");
+
         return CommandServoJointResult::SLAVE_MOVE_FAILED;
     }
 

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -367,22 +367,7 @@ namespace denso_controller
 
     BCAP_HRESULT DensoReadWriteDriver::SlvMove(BCAP_VARIANT *pose, BCAP_VARIANT *result)
     {
-        BCAP_HRESULT hr;
-        for (size_t attempt = 0; attempt < 3; ++attempt)
-        {
-            hr = bCap_RobotExecute2(iSockFD, lhRobot, "slvMove", pose, result);
-            if (SUCCEEDED(hr))
-            {
-                break;
-            }
-            SPDLOG_WARN("Failed to execute slvMove, attempt " + std::to_string(attempt));
-            ClearError();
-        }
-        if (FAILED(hr))
-        {
-            SPDLOG_ERROR("Failed to execute b-CAP slave move.");
-        }
-        return hr;
+        return bCap_RobotExecute2(iSockFD, lhRobot, "slvMove", pose, result);
     }
 
     BCAP_HRESULT DensoReadWriteDriver::ForceSensor(const char *mode)
@@ -490,19 +475,13 @@ namespace denso_controller
         return {hr, joint_positions};
     }
 
-    bool DensoController::ExecuteServoTrajectory(
+    std::tuple<DensoController::ExecuteServoTrajectoryError, DensoController::ExecuteServoTrajectoryResult>
+    DensoController::ExecuteServoTrajectory(
         const RobotTrajectory &traj,
         const std::optional<double> total_force_limit,
         const std::optional<double> total_torque_limit,
         const std::optional<std::vector<double>> per_axis_force_torque_limits)
     {
-        // std::cout << total_force_limit << " " << total_torque_limit << " "
-        //           << per_axis_force_torque_limits << std::endl;
-
-        bool trajectory_execution_finished = true;
-        BCAP_HRESULT hr;
-        long lResult;
-
         auto arm_mutex = DensoArmMutex(write_driver);
 
         if (total_force_limit.has_value()
@@ -514,10 +493,11 @@ namespace denso_controller
             // Reset the force sensor to prevent drift in the force readings.
             // Do it here, instead of in the force sensing thread, because this call
             // requires the arm mutex.
-            hr = write_driver.ForceSensor("0");
+            write_driver.ForceSensor("0");
+            // TODO: handle error
         }
 
-        // Start a thread to stream force sensor data, setting the
+        // Start a thread to stream force sensor data
         force_limit_exceeded = false;
         std::thread force_sensing_thread(
             &DensoController::RunForceSensingLoop,
@@ -527,18 +507,25 @@ namespace denso_controller
             per_axis_force_torque_limits);
 
         // Enter slave mode
-        hr = write_driver.SlvChangeMode(SERVO_MODE_ON);
-        if (FAILED(hr))
+        SPDLOG_INFO("Entering slave mode");
+        switch (EnterSlaveMode())
         {
-            std::string err_description = GetErrorDescription(hr);
-            SPDLOG_ERROR("Failed to enter b-CAP slave mode." + err_description);
-            throw EnterSlaveModeException(err_description);
+            case EnterSlaveModeResult::SUCCESS:
+                SPDLOG_INFO("Slave mode ON");
+                break;
+            case EnterSlaveModeResult::ENTER_SLAVE_MODE_FAILED:
+                // TODO: Get the stack of errors from the controller
+                // std::string err_description = GetErrorDescription(hr);
+                SPDLOG_ERROR("Failed to enter b-CAP slave mode.");  // + err_description);
+                return {
+                    ExecuteServoTrajectoryError::ENTER_SLAVE_MODE_FAILED,
+                    ExecuteServoTrajectoryResult::ERROR
+                };
         }
-        SPDLOG_INFO("Slave mode ON");
-        auto slave_mode_on = std::chrono::steady_clock::now();
 
         // Execute the trajectory
-        BCAP_VARIANT vntPose, vntReturn;
+        // BCAP_VARIANT vntPose, vntReturn;
+        CommandServoJointResult result;
         for (size_t i = 0; i < traj.size(); i++)
         {
             current_waypoint_index = i;
@@ -546,31 +533,38 @@ namespace denso_controller
             if (current_waypoint_index > 4 && force_limit_exceeded)
             {
                 SPDLOG_INFO("Force limit exceeded after " + std::to_string(current_waypoint_index) + " waypoints. Stopping trajectory execution.");
-                trajectory_execution_finished = false;
                 break;
             }
 
             const auto &joint_position = traj.trajectory[i];
-            vntPose = VNTFromRadVector(joint_position);
-            if (i == 0) {
-                auto time_of_first_move = std::chrono::steady_clock::now();
-                auto elapsed = time_of_first_move - slave_mode_on;
-                SPDLOG_INFO("Time to first move: " + std::to_string(elapsed.count()));
-            }
-
-            hr = write_driver.SlvMove(&vntPose, &vntReturn);
-
-            if (FAILED(hr))
+            // vntPose = VNTFromRadVector(joint_position);
+            // if (i == 0) {
+            //     auto time_of_first_move = std::chrono::steady_clock::now();
+            //     auto elapsed = time_of_first_move - slave_mode_on;
+            //     SPDLOG_INFO("Time to first move: " + std::to_string(elapsed.count()));
+            // }
+            result = CommandServoJoint(joint_position);
+            switch (result)
             {
-                // Stop the force sensing thread to prevent it from running indefinitely.
-                force_limit_exceeded = true;
-                force_sensing_thread.join();
+                case CommandServoJointResult::SUCCESS:
+                    break;
+                case CommandServoJointResult::SLAVE_MOVE_FAILED:
+                    SPDLOG_ERROR("ExecuteServoTrajectory failed at waypoint " + std::to_string(i));
 
-                std::string err_description = GetErrorDescription(hr);
-                SPDLOG_ERROR("Failed to execute b-CAP slave move. " + err_description);
-                std::string msg = "Index " + std::to_string(i) + " of " + std::to_string(traj.size()) + " ErrDescription: " + err_description;
+                    // Stop the force sensing thread to prevent it from running indefinitely.
+                    force_limit_exceeded = true;
+                    force_sensing_thread.join();
 
-                throw SlaveMoveException(msg);
+                    // std::string err_description = GetErrorDescription(hr);
+                    // SPDLOG_ERROR("Error description: " + err_description);
+
+                    // No need to exit slave mode here because the controller
+                    // releases slave mode when an error occurs.
+
+                    return {
+                        ExecuteServoTrajectoryError::SLAVE_MOVE_FAILED,
+                        ExecuteServoTrajectoryResult::ERROR
+                    };
             }
 
             // Print the joint positions
@@ -582,31 +576,54 @@ namespace denso_controller
         }
 
         bool exec_complete = !force_limit_exceeded;
-        // Stop the force sensing thread.
+        // Stop the force sensing thread by triggering the stop condition.
+        // Don't join the force sensing thread here because it may block this
+        // thread for too long, causing command position buffer underflow.
         force_limit_exceeded = true;
 
         // Close loop servo commands on last waypoint.
         if (exec_complete)
         {
-            ClosedLoopCommandServoJoint(traj.trajectory.back());
+            switch (ClosedLoopCommandServoJoint(traj.trajectory.back()))
+            {
+                case ClosedLoopCommandServoJointResult::SUCCESS:
+                    SPDLOG_INFO("Closed loop servo joint commands successful");
+                    break;
+                default:  // failure
+                    // The trajectory is essentially complete at this point, so we
+                    // don't do anything special if the closed loop commands fail.
+                    SPDLOG_ERROR("Closed loop servo joint commands failed");
+                    ClearError();
+                    break;
+            }
         }
         force_sensing_thread.join();
 
+        ExecuteServoTrajectoryResult trajectory_result = (
+            exec_complete ?
+            ExecuteServoTrajectoryResult::COMPLETE :
+            ExecuteServoTrajectoryResult::FORCE_LIMIT_EXCEEDED
+        );
+
         SPDLOG_INFO("Turning off slave mode");
-
-        hr = write_driver.SlvChangeMode(SERVO_MODE_OFF);
-        // Exit slave mode
-        if (FAILED(hr))
+        switch (ExitSlaveMode())
         {
-            std::string err_description = GetErrorDescription(hr);
-            SPDLOG_ERROR("Failed to exit b-CAP slave mode." + err_description);
-            throw ExitSlaveModeException(err_description);
+            case ExitSlaveModeResult::SUCCESS:
+                SPDLOG_INFO("Slave mode OFF");
+                break;
+            case ExitSlaveModeResult::EXIT_SLAVE_MODE_FAILED:
+                // std::string err_description = GetErrorDescription(hr);
+                // SPDLOG_ERROR("Failed to exit b-CAP slave mode." + err_description);
+                return {
+                    ExecuteServoTrajectoryError::EXIT_SLAVE_MODE_FAILED,
+                    trajectory_result
+                };
         }
-        SPDLOG_INFO("Slave mode OFF");
 
-        // SPDLOG_INFO("Exec traj done");
-
-        return trajectory_execution_finished;
+        return {
+            ExecuteServoTrajectoryError::SUCCESS,
+            trajectory_result
+        };
     }
 
     void DensoController::RunForceSensingLoop(
@@ -711,7 +728,8 @@ namespace denso_controller
         force_sensing_log.close();
     }
 
-    void DensoController::ClosedLoopCommandServoJoint(const std::vector<double>& last_waypoint)
+    DensoController::ClosedLoopCommandServoJointResult
+    DensoController::ClosedLoopCommandServoJoint(const std::vector<double>& last_waypoint)
     {
         SPDLOG_INFO("Closed loop servo joint commands");
         /* Repeat the last servo j command until the robot reaches tolerance or timeout */
@@ -755,7 +773,7 @@ namespace denso_controller
             if (FAILED(hr))
             {
                 SPDLOG_ERROR("Closed loop servo j commands failed to get current joint position");
-                break;
+                return ClosedLoopCommandServoJointResult::GET_CUR_JNT_FAILED;
             }
             current_jnt_rad = VDeg2Rad(current_jnt_deg);
 
@@ -776,7 +794,12 @@ namespace denso_controller
             // Command the last waypoint again
             BCAP_VARIANT vntPose = VNTFromRadVector(last_waypoint);
             BCAP_VARIANT vntReturn;
-            write_driver.SlvMove(&vntPose, &vntReturn);
+            auto result = CommandServoJoint(last_waypoint);
+            if (result != CommandServoJointResult::SUCCESS)
+            {
+                SPDLOG_ERROR("Closed loop servo j commands failed to command servo joint");
+                return ClosedLoopCommandServoJointResult::SLAVE_MOVE_FAILED;
+            }
 
             count++;
         }
@@ -791,6 +814,8 @@ namespace denso_controller
         std::sprintf(buffer, "After %d closed-loop servo commands, joint error: [%.4f, %.4f, %.4f, %.4f, %.4f, %.4f]",
                      count, joint_error[0], joint_error[1], joint_error[2], joint_error[3], joint_error[4], joint_error[5]);
         SPDLOG_DEBUG(std::string(buffer));
+
+        return ClosedLoopCommandServoJointResult::SUCCESS;
     }
 
     void DensoController::HandleError(BCAP_HRESULT error_code, const char *error_description)
@@ -803,6 +828,54 @@ namespace denso_controller
         Stop();
         throw bCapException(
             "Error code: " + std::to_string(error_code) + ". Error description: " + error_description + ". Controller error message: " + controller_error);
+    }
+
+    DensoController::EnterSlaveModeResult
+    DensoController::EnterSlaveMode() {
+        BCAP_HRESULT hr = write_driver.SlvChangeMode(SERVO_MODE_ON);
+        if (FAILED(hr))
+        {
+            SPDLOG_ERROR("Failed to enter b-CAP slave mode.");
+            return EnterSlaveModeResult::ENTER_SLAVE_MODE_FAILED;
+        }
+        return EnterSlaveModeResult::SUCCESS;
+    }
+
+    DensoController::ExitSlaveModeResult
+    DensoController::ExitSlaveMode() {
+        BCAP_HRESULT hr = write_driver.SlvChangeMode(SERVO_MODE_OFF);
+        if (FAILED(hr))
+        {
+            SPDLOG_ERROR("Failed to exit b-CAP slave mode.");
+            return ExitSlaveModeResult::EXIT_SLAVE_MODE_FAILED;
+        }
+        return ExitSlaveModeResult::SUCCESS;
+    }
+
+    DensoController::CommandServoJointResult
+    DensoController::CommandServoJoint(const std::vector<double> &joint_position)
+    {
+        BCAP_VARIANT vntPose = VNTFromRadVector(joint_position);
+        BCAP_VARIANT vntReturn;
+        BCAP_HRESULT hr;
+        for (size_t attempt = 0; attempt < 3; ++attempt)
+        {
+            hr = write_driver.SlvMove(&vntPose, &vntReturn);
+            if (SUCCEEDED(hr))
+            {
+                return CommandServoJointResult::SUCCESS;
+            }
+            SPDLOG_WARN("Failed to command servo joint, attempt " + std::to_string(attempt));
+            ClearError();
+            EnterSlaveMode();  // If this call fails, it will be caught in the next iteration
+        }
+
+        if (FAILED(hr))
+        {
+            SPDLOG_ERROR("Failed to command servo joint.");
+            return CommandServoJointResult::SLAVE_MOVE_FAILED;
+        }
+        return CommandServoJointResult::SUCCESS;
     }
 
     ////////////////////////////// Utilities //////////////////////////////

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -552,7 +552,11 @@ namespace denso_controller
                 case CommandServoJointResult::SUCCESS:
                     break;
                 case CommandServoJointResult::SLAVE_MOVE_FAILED:
-                    SPDLOG_ERROR("ExecuteServoTrajectory failed at waypoint " + std::to_string(i));
+                    SPDLOG_ERROR(
+                        "ExecuteServoTrajectory failed at waypoint "
+                        + std::to_string(i)
+                        + " of " + std::to_string(traj.size())
+                    );
 
                     // Stop the force sensing thread to prevent it from running indefinitely.
                     force_limit_exceeded = true;
@@ -872,6 +876,7 @@ namespace denso_controller
             for (auto error : VALID_SLVMOVE_ERRORS) {
                 if (hr == error) {
                     is_valid_error = true;
+                    SPDLOG_WARN("Matched buffer underflow error: " + std::to_string(error));
                     break;
                 }
             }
@@ -882,7 +887,9 @@ namespace denso_controller
                 write_driver.Motor(true);
                 EnterSlaveMode();  // If this call fails, it will be caught in the next iteration
             } else {
-                SPDLOG_ERROR("Command servo joint failed. Not retrying.");
+                SPDLOG_ERROR("Command servo joint failed with code "
+                             + std::to_string(hr)
+                             + ". Not retrying.");
                 return CommandServoJointResult::SLAVE_MOVE_FAILED;
             }
         }

--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -532,7 +532,10 @@ namespace denso_controller
             // Stop if the force exceedance condition is true
             if (current_waypoint_index > 4 && force_limit_exceeded)
             {
-                SPDLOG_INFO("Force limit exceeded after " + std::to_string(current_waypoint_index) + " waypoints. Stopping trajectory execution.");
+                SPDLOG_INFO("Force limit exceeded after "
+                            + std::to_string(current_waypoint_index)
+                            + " of " + std::to_string(traj.size())
+                            + " waypoints. Stopping trajectory execution.");
                 break;
             }
 

--- a/medra_pybind/src/bindings.cpp
+++ b/medra_pybind/src/bindings.cpp
@@ -13,47 +13,6 @@ namespace py = pybind11;
 using namespace denso_controller;
 
 PYBIND11_MODULE(_medra_bcap, m) {
-  py::class_<BCAP_VARIANT>(m, "BCAP_VARIANT")
-    .def(py::init<>())
-    .def_readwrite("Type", &BCAP_VARIANT::Type)
-    .def_readwrite("Arrays", &BCAP_VARIANT::Arrays)
-    .def_property("CharValue",
-                  [](BCAP_VARIANT &v) { return v.Value.CharValue; },
-                  [](BCAP_VARIANT &v, u_char value) { v.Value.CharValue = value; })
-    .def_property("ShortValue",
-                  [](BCAP_VARIANT &v) { return v.Value.ShortValue; },
-                  [](BCAP_VARIANT &v, u_short value) { v.Value.ShortValue = value; })
-    .def_property("LongValue",
-                  [](BCAP_VARIANT &v) { return v.Value.LongValue; },
-                  [](BCAP_VARIANT &v, uint32_t value) { v.Value.LongValue = value; })
-    .def_property("FloatValue",
-                  [](BCAP_VARIANT &v) { return v.Value.FloatValue; },
-                  [](BCAP_VARIANT &v, float value) { v.Value.FloatValue = value; })
-    .def_property("DoubleValue",
-                  [](BCAP_VARIANT &v) { return v.Value.DoubleValue; },
-                  [](BCAP_VARIANT &v, double value) { v.Value.DoubleValue = value; })
-    .def_property("String", 
-                  [](BCAP_VARIANT &v) { return std::string(reinterpret_cast<char*>(v.Value.String)); },
-                  [](BCAP_VARIANT &v, const std::string &str) { 
-                    strncpy(reinterpret_cast<char*>(v.Value.String), str.c_str(), 40); 
-                    v.Value.String[40] = '\0'; 
-                  })
-    .def_property("FloatArray", 
-                  [](BCAP_VARIANT &v) { return py::array_t<float>({16}, v.Value.FloatArray); },
-                  [](BCAP_VARIANT &v, py::array_t<float> arr) { 
-                    auto buf = arr.request();
-                    std::memcpy(v.Value.FloatArray, buf.ptr, 16 * sizeof(float)); 
-                  })
-    .def_property("DoubleArray", 
-                  [](BCAP_VARIANT &v) { return py::array_t<double>({16}, v.Value.DoubleArray); },
-                  [](BCAP_VARIANT &v, py::array_t<double> arr) { 
-                    auto buf = arr.request();
-                    std::memcpy(v.Value.DoubleArray, buf.ptr, 16 * sizeof(double)); 
-                  })
-    .def_property("Data",
-                  [](BCAP_VARIANT &v) { return reinterpret_cast<uintptr_t>(v.Value.Data); },
-                  [](BCAP_VARIANT &v, uintptr_t data) { v.Value.Data = reinterpret_cast<void*>(data); });
-
   py::class_<RobotTrajectory>(m, "RobotTrajectory")
     .def(py::init<>())
     .def_readonly("dimension", &RobotTrajectory::dimension)
@@ -64,6 +23,17 @@ PYBIND11_MODULE(_medra_bcap, m) {
   py::register_exception<SlaveMoveException>(m, "SlaveMoveException");
   py::register_exception<EnterSlaveModeException>(m, "EnterSlaveModeException");
   py::register_exception<ExitSlaveModeException>(m, "ExitSlaveModeException");
+
+  py::enum_<DensoController::ExecuteServoTrajectoryError>(m, "ExecuteServoTrajectoryError")
+    .value("SUCCESS", DensoController::ExecuteServoTrajectoryError::SUCCESS)
+    .value("ENTER_SLAVE_MODE_FAILED", DensoController::ExecuteServoTrajectoryError::ENTER_SLAVE_MODE_FAILED)
+    .value("SLAVE_MOVE_FAILED", DensoController::ExecuteServoTrajectoryError::SLAVE_MOVE_FAILED)
+    .value("EXIT_SLAVE_MODE_FAILED", DensoController::ExecuteServoTrajectoryError::EXIT_SLAVE_MODE_FAILED);
+  
+  py::enum_<DensoController::ExecuteServoTrajectoryResult>(m, "ExecuteServoTrajectoryResult")
+    .value("COMPLETE", DensoController::ExecuteServoTrajectoryResult::COMPLETE)
+    .value("FORCE_LIMIT_EXCEEDED", DensoController::ExecuteServoTrajectoryResult::FORCE_LIMIT_EXCEEDED)
+    .value("ERROR", DensoController::ExecuteServoTrajectoryResult::ERROR);
 
   py::class_<DensoController>(m, "DensoController")
     .def(py::init<>())

--- a/medra_pybind/tests/test_execute_servo_trajectory.cpp
+++ b/medra_pybind/tests/test_execute_servo_trajectory.cpp
@@ -77,21 +77,32 @@ int main(){
     for (size_t iters = 0; iters < 100000; ++iters) {
         // std::optional<std::vector<double>> force_vector = std::vector<double>{10000.0, 10000.0, 10.0, 10000.0, 10000.0, 10000.0};
         auto total_force_limit = 10.0;
-        if (!controller.ExecuteServoTrajectory(
+        auto result = controller.ExecuteServoTrajectory(
             forward_trajectory,
             total_force_limit,
             std::nullopt,
             std::nullopt
-        )) {
+        );
+        if (std::get<0>(result) != denso_controller::DensoController::ExecuteServoTrajectoryError::SUCCESS) {
+            std::cout << "Error executing forward trajectory" << std::endl;
+            break;
+        }
+        if (std::get<1>(result) == denso_controller::DensoController::ExecuteServoTrajectoryResult::FORCE_LIMIT_EXCEEDED) {
             std::cout << "Stopped early" << std::endl;
             break;
         }
-        if (!controller.ExecuteServoTrajectory(
+
+        result = controller.ExecuteServoTrajectory(
             reverse_trajectory,
             total_force_limit,
             std::nullopt,
             std::nullopt
-        )) {
+        );
+        if (std::get<0>(result) != denso_controller::DensoController::ExecuteServoTrajectoryError::SUCCESS) {
+            std::cout << "Error executing reverse trajectory" << std::endl;
+            break;
+        }
+        if (std::get<1>(result) == denso_controller::DensoController::ExecuteServoTrajectoryResult::FORCE_LIMIT_EXCEEDED) {
             std::cout << "Stopped early" << std::endl;
             break;
         }

--- a/medra_pybind/tests/test_execute_servo_trajectory.cpp
+++ b/medra_pybind/tests/test_execute_servo_trajectory.cpp
@@ -16,13 +16,7 @@
 #define AMPLITUDE  1
 
 int main(){
-    int iSockFD;
-    uint32_t lResult;
-    uint32_t lhController, lhRobot;
     BCAP_HRESULT hr = BCAP_S_OK;
-
-    double dJnt[8];
-    BCAP_VARIANT vntPose, vntReturn;
 
     denso_controller::DensoController controller;
     controller.Start();
@@ -66,12 +60,10 @@ int main(){
         currentPose = newPose;
     }
 
-    const size_t dimension = 6;
     RobotTrajectory forward_trajectory;
     forward_trajectory.trajectory = forward_trajectory_poses;
     RobotTrajectory reverse_trajectory;
     reverse_trajectory.trajectory = reverse_trajectory_poses;
-
 
     // Execute the trajectory
     for (size_t iters = 0; iters < 100000; ++iters) {


### PR DESCRIPTION
- Remove erroneous retry logic for SlvMove()
- Return information from ExecuteServoTrajectory() about the conditions under which the function exited
- Eliminate some exceptions in favor of status codes
- Bump package version to 0.1.9