### PR TITLE
fix: Add missing thread join

### DIFF
--- a/medra_pybind/src/DensoController.cpp
+++ b/medra_pybind/src/DensoController.cpp
@@ -521,6 +521,7 @@ namespace denso_controller
                 break;
             case EnterSlaveModeResult::ENTER_SLAVE_MODE_FAILED:
                 SPDLOG_ERROR("Failed to enter b-CAP slave mode.");  // + err_description);
+                force_sensing_thread.join();
                 return {
                     ExecuteServoTrajectoryError::ENTER_SLAVE_MODE_FAILED,
                     ExecuteServoTrajectoryResult::ERROR


### PR DESCRIPTION
- Missing a thread join; can lead to std::terminate